### PR TITLE
GLSLシェーダーの警告抑制

### DIFF
--- a/UnityFigmaBridge/Runtime/Resources/Shaders/FigmaImageShader.shader
+++ b/UnityFigmaBridge/Runtime/Resources/Shaders/FigmaImageShader.shader
@@ -156,6 +156,8 @@ Shader "Figma/FigmaImageShader"
                     clampedCornerRadius.w/=max(cornerSizeBottomRatio,cornerSizeLeftRatio);
                 
                     OUT.clamped_corner_radius=clampedCornerRadius;
+                #else
+                    OUT.clamped_corner_radius=0;
                 #endif
                 
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "unity": "2021.3",
   "unityRelease": "0f1",
-  "version": "1.0.8",
+  "version": "1.0.8+techcross.1",
   "type": "library",
   "hideInEditor": false,
   "dependencies": {


### PR DESCRIPTION
WebGLで実行時の警告 `GLSL link error: FRAGMENT varying vs_TEXCOORD4 does not match any VERTEX varying` を抑制する。
![image](https://github.com/user-attachments/assets/51ad8b88-332c-418d-8b26-6caf1a95eeca)


この警告は、頂点シェーダーで定義されている TEXCOORD4（clamped_corner_radius）が、フラグメントシェーダーで全く使用されていない ことが原因である可能性が高い。
#if ディレクティブの中でしか使われていなかった clamped_corner_radius を #else でも初期化するようにした。