### PR TITLE
カスタムコンポーネントアタッチ機能の例外処理追加

### DIFF
--- a/UnityFigmaBridge/Editor/PrototypeFlow/BehaviourBindingManager.cs
+++ b/UnityFigmaBridge/Editor/PrototypeFlow/BehaviourBindingManager.cs
@@ -27,6 +27,7 @@ namespace UnityFigmaBridge.Editor.PrototypeFlow
         {
 			// カスタムコンポーネントのアタッチ設定をチェックして実行
 			CustomComponentAttachManager.ApplySettingGameObject(gameObject);
+			if(!gameObject) return;
 
             // Add in any special behaviours driven by name or other rules. If special case, dont add any more behaviours
             bool specialCaseNode=AddSpecialBehavioursToNode(gameObject,importProcessData);
@@ -45,6 +46,7 @@ namespace UnityFigmaBridge.Editor.PrototypeFlow
 
 			// 同名型のコンポーネントアタッチ処理を試行
 			CustomComponentAttachManager.TryAttachComponent(gameObject, matchingType);
+			if(!gameObject) return;
 
             if (!matchingType.IsSubclassOf(typeof(MonoBehaviour)))
             {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "unity": "2021.3",
   "unityRelease": "0f1",
-  "version": "1.0.8+techcross.4",
+  "version": "1.0.8+techcross.5",
   "type": "library",
   "hideInEditor": false,
   "dependencies": {


### PR DESCRIPTION
カスタムコンポーネントアタッチの際に不要オブジェクトを削除する際にNull参照になっていたのを例外処理を挟むように修正