### PR TITLE
バックアップがすでにあるときは削除してからコピーするよう修正

### DIFF
--- a/UnityFigmaBridge/Editor/Components/ComponentManager.cs
+++ b/UnityFigmaBridge/Editor/Components/ComponentManager.cs
@@ -83,6 +83,10 @@ namespace UnityFigmaBridge.Editor.Components
                 // 元となるプレハブが存在する場合はバックアップを取る
                 var backupPath = FigmaPaths.MakeBackupPath(prefabAssetPath);
                 Directory.CreateDirectory(Path.GetDirectoryName(backupPath) ?? string.Empty);
+                if (AssetDatabase.LoadAssetAtPath<Object>(backupPath))
+                {
+                    AssetDatabase.DeleteAsset(backupPath);
+                }
                 AssetDatabase.CopyAsset(prefabAssetPath, backupPath);
             }
             

--- a/UnityFigmaBridge/Editor/Components/ComponentManager.cs
+++ b/UnityFigmaBridge/Editor/Components/ComponentManager.cs
@@ -83,10 +83,7 @@ namespace UnityFigmaBridge.Editor.Components
                 // 元となるプレハブが存在する場合はバックアップを取る
                 var backupPath = FigmaPaths.MakeBackupPath(prefabAssetPath);
                 Directory.CreateDirectory(Path.GetDirectoryName(backupPath) ?? string.Empty);
-                if (AssetDatabase.LoadAssetAtPath<Object>(backupPath))
-                {
-                    AssetDatabase.DeleteAsset(backupPath);
-                }
+                AssetDatabase.DeleteAsset(backupPath);
                 AssetDatabase.CopyAsset(prefabAssetPath, backupPath);
             }
             


### PR DESCRIPTION
import後に設定したコンポーネントをアタッチする為に
プレハブのバックアップを取る際、保存先にすでにファイルがあるとき上書きされない場合があったので、
削除してからコピーするように修正