### PR TITLE
コピースキップ対象を修正

### DIFF
--- a/UnityFigmaBridge/Editor/Components/ComponentManager.cs
+++ b/UnityFigmaBridge/Editor/Components/ComponentManager.cs
@@ -491,6 +491,11 @@ namespace UnityFigmaBridge.Editor.Components
             typeof(FigmaNodeObject),
             typeof(FigmaComponentNodeMarker),
             typeof(InstanceSwapMarker),
+            
+            // 以下は常にFigmaの設定の方が正なので上書きしない
+            typeof(TextMeshPro),
+            typeof(LayoutElement),
+            typeof(LayoutGroup),
         };
     }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "unity": "2021.3",
   "unityRelease": "0f1",
-  "version": "1.0.8+techcross.8",
+  "version": "1.0.8+techcross.9",
   "type": "library",
   "hideInEditor": false,
   "dependencies": {


### PR DESCRIPTION
FigmaDataの方が正しいコンポーネントはコピーしないように修正