### PR TITLE
画像名をノード名に、FigmaImageを極力Imageに

### DIFF
--- a/UnityFigmaBridge/Editor/Components/ComponentManager.cs
+++ b/UnityFigmaBridge/Editor/Components/ComponentManager.cs
@@ -358,13 +358,32 @@ namespace UnityFigmaBridge.Editor.Components
                         {
                             break;
                         }
-                        
-                        var swapDefaultNode = figmaImportProcessData.NodeLookupDictionary[value.defaultValue];
+
+                        var nodeLookup = figmaImportProcessData.NodeLookupDictionary;
+                        var markTargetName = "";
+
+                        if (nodeLookup.TryGetValue(value.defaultValue, out var swapDefaultNode))
+                        {
+                            markTargetName = swapDefaultNode.name;
+                        }
+                        // 読み込み対象にデフォルトノードが存在していない場合は、マーカーを参照して置き換え対象を取得する
+                        else
+                        {
+                            var componentMarkers = obj.GetComponentsInChildren<FigmaComponentNodeMarker>(true);
+                            foreach (var componentMarker in componentMarkers)
+                            {
+                                if (componentMarker.ComponentId == value.defaultValue)
+                                {
+                                    markTargetName = componentMarker.name;
+                                    break;
+                                }
+                            }
+                        }
                         var replacementNode = figmaImportProcessData.NodeLookupDictionary[property.value];
 
                         var marker = obj.AddComponent<InstanceSwapMarker>();
                         var swapComponentPrefab = figmaImportProcessData.ComponentData.GetComponentPrefab(replacementNode.id);
-                        marker.targetName = swapDefaultNode.name;
+                        marker.targetName = markTargetName;
                         marker.replacementPrefab = swapComponentPrefab;
 
                         break;

--- a/UnityFigmaBridge/Editor/Extension/ImportCache/ImportSessionCache.cs
+++ b/UnityFigmaBridge/Editor/Extension/ImportCache/ImportSessionCache.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+
+namespace UnityFigmaBridge.Editor.Extension.ImportCache
+{
+    /// <summary>
+    /// 1回のインポートで利用するキャッシュデータをまとめておくクラス
+    /// </summary>
+    public static class ImportSessionCache
+    {
+        // 画像名取得用コンテナ　(imageRef, 画像のノード名(＝画像名))
+        public static Dictionary<string, string> imageNameMap = new Dictionary<string, string>();
+        // 画像名重複数保持用コンテナ　(画像名, 画像数)
+        public static Dictionary<string, int> imageNameCountMap = new Dictionary<string, int>();
+
+        public static void CacheClear()
+        {
+            imageNameMap.Clear();
+            imageNameCountMap.Clear();
+        }
+    }
+}

--- a/UnityFigmaBridge/Editor/Extension/ImportCache/ImportSessionCache.cs.meta
+++ b/UnityFigmaBridge/Editor/Extension/ImportCache/ImportSessionCache.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e4767cf7dad0431e9969333501fd1394
+timeCreated: 1754377206

--- a/UnityFigmaBridge/Editor/FigmaApi/FigmaApiUtils.cs
+++ b/UnityFigmaBridge/Editor/FigmaApi/FigmaApiUtils.cs
@@ -266,12 +266,12 @@ namespace UnityFigmaBridge.Editor.FigmaApi
             foreach (var keyPair in imageFillData.meta.images)
             {
                 // Only download if it is used in the document and not already downloaded
-                if (foundImageFills.ContainsKey(keyPair.Key) && !map.AssetExists(keyPair.Key))
+                if (foundImageFills.TryGetValue(keyPair.Key, out var imageName) && !map.AssetExists(keyPair.Key))
                 {
                     downloadList.Add(new FigmaDownloadQueueItem
                     {
                         Url=keyPair.Value,
-                        FilePath = FigmaPaths.GetPathForImageFill(keyPair.Key, foundImageFills[keyPair.Key]),
+                        FilePath = FigmaPaths.GetPathForImageFill(keyPair.Key, imageName),
                         FileType = FigmaDownloadQueueItem.FigmaFileType.ImageFill
                     });
                 }

--- a/UnityFigmaBridge/Editor/FigmaApi/FigmaApiUtils.cs
+++ b/UnityFigmaBridge/Editor/FigmaApi/FigmaApiUtils.cs
@@ -257,7 +257,7 @@ namespace UnityFigmaBridge.Editor.FigmaApi
         /// <param name="serverRenderData"></param>
         /// <param name="serverRenderNodes"></param>
         /// <returns></returns>
-        public static List<FigmaDownloadQueueItem> GenerateDownloadQueue(FigmaImageFillData imageFillData,List<string> foundImageFills,List<FigmaServerRenderData> serverRenderData,List<ServerRenderNodeData> serverRenderNodes)
+        public static List<FigmaDownloadQueueItem> GenerateDownloadQueue(FigmaImageFillData imageFillData,Dictionary<string, string> foundImageFills,List<FigmaServerRenderData> serverRenderData,List<ServerRenderNodeData> serverRenderNodes)
         {
             var map = FigmaAssetGuidMapManager.GetMap(FigmaAssetGuidMapManager.AssetType.ImageFill);
             // Check if each image fill file has already been downloaded. If not, add to download list
@@ -266,12 +266,12 @@ namespace UnityFigmaBridge.Editor.FigmaApi
             foreach (var keyPair in imageFillData.meta.images)
             {
                 // Only download if it is used in the document and not already downloaded
-                if (foundImageFills.Contains(keyPair.Key) && !map.AssetExists(keyPair.Key))
+                if (foundImageFills.ContainsKey(keyPair.Key) && !map.AssetExists(keyPair.Key))
                 {
                     downloadList.Add(new FigmaDownloadQueueItem
                     {
                         Url=keyPair.Value,
-                        FilePath = FigmaPaths.GetPathForImageFill(keyPair.Key),
+                        FilePath = FigmaPaths.GetPathForImageFill(keyPair.Key, foundImageFills[keyPair.Key]),
                         FileType = FigmaDownloadQueueItem.FigmaFileType.ImageFill
                     });
                 }

--- a/UnityFigmaBridge/Editor/FigmaApi/FigmaDataUtils.cs
+++ b/UnityFigmaBridge/Editor/FigmaApi/FigmaDataUtils.cs
@@ -249,10 +249,15 @@ namespace UnityFigmaBridge.Editor.FigmaApi
                     if (!imageFillList.ContainsKey(imageRefId))
                     {
                         var imageName = node.name;
-                        if (!imageNameCountMap.TryAdd(node.name, 1))
+                        if (imageNameCountMap.TryGetValue(node.name, out var count))
                         {
-                            var count = ++imageNameCountMap[node.name];
+                            count++;
+                            imageNameCountMap[node.name] = count;
                             imageName += $"_{count}";
+                        }
+                        else
+                        {
+                            imageNameCountMap.Add(node.name, 1);
                         }
                         imageFillList.Add(imageRefId, imageName);
                     }

--- a/UnityFigmaBridge/Editor/Nodes/FigmaNodeManager.cs
+++ b/UnityFigmaBridge/Editor/Nodes/FigmaNodeManager.cs
@@ -49,6 +49,21 @@ namespace UnityFigmaBridge.Editor.Nodes
                         break;
                     }
                     
+                    // FigmaImageである必要がなければ、Imageをアタッチ
+                    if (node.type != NodeType.ELLIPSE &&
+                        node.type != NodeType.STAR &&
+                        node.rectangleCornerRadii == null &&
+                        node.cornerRadius == 0 &&
+                        node.strokes.Length == 0 &&
+                        (node.fills.Length > 0 && node.fills[0].type == Paint.PaintType.IMAGE))
+                    {
+                        var image = UnityUiUtils.GetOrAddComponent<Image>(nodeGameObject);
+                        var firstFill = node.fills[0];
+                        var sprite = AssetDatabase.LoadAssetAtPath<Sprite>(FigmaPaths.GetPathForImageFill(firstFill.imageRef, ImportSessionCache.imageNameMap[firstFill.imageRef]));
+                        image.sprite = sprite;
+                        return;
+                    }
+                    
                     // Create as needed (in case an override has specified new properties)
                     var figmaImage = nodeGameObject.GetComponent<FigmaImage>();
                     if (figmaImage == null) figmaImage = nodeGameObject.AddComponent<FigmaImage>();
@@ -116,7 +131,8 @@ namespace UnityFigmaBridge.Editor.Nodes
                     text.color = FigmaDataUtils.GetUnityFillColor(node.fills[0]);
                     text.fontSize = node.style.fontSize;
                     text.characterSpacing = -0.7f; // Figma handles spacing a little differently
-                   
+                    text.raycastTarget = false;// 文字には基本当たり判定不要なので、初期値をfalseに
+                    
                     text.horizontalAlignment = node.style.textAlignHorizontal switch
                     {
                         TypeStyle.TextAlignHorizontal.LEFT => HorizontalAlignmentOptions.Left,

--- a/UnityFigmaBridge/Editor/Nodes/FigmaNodeManager.cs
+++ b/UnityFigmaBridge/Editor/Nodes/FigmaNodeManager.cs
@@ -3,6 +3,7 @@ using TMPro;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.UI;
+using UnityFigmaBridge.Editor.Extension.ImportCache;
 using UnityFigmaBridge.Editor.FigmaApi;
 using UnityFigmaBridge.Editor.Fonts;
 using UnityFigmaBridge.Editor.Utils;
@@ -41,7 +42,7 @@ namespace UnityFigmaBridge.Editor.Nodes
                         var image = nodeGameObject.GetComponent<Image>();
                         if (image == null) image = nodeGameObject.AddComponent<Image>();
                         var firstFill = node.fills[0];
-                        var sprite = AssetDatabase.LoadAssetAtPath<Sprite>(FigmaPaths.GetPathForImageFill(firstFill.imageRef));
+                        var sprite = AssetDatabase.LoadAssetAtPath<Sprite>(FigmaPaths.GetPathForImageFill(firstFill.imageRef, ImportSessionCache.imageNameMap[firstFill.imageRef]));
                         image.sprite = sprite;
                         image.type = Image.Type.Sliced;
 
@@ -298,7 +299,7 @@ namespace UnityFigmaBridge.Editor.Nodes
                 switch (firstFill.type)
                 {
                     case Paint.PaintType.IMAGE:
-                        SetupImageFill(figmaImage, firstFill);
+                       SetupImageFill(figmaImage, firstFill);
                         break;
                     case Paint.PaintType.GRADIENT_LINEAR:
                     case Paint.PaintType.GRADIENT_RADIAL:
@@ -355,8 +356,12 @@ namespace UnityFigmaBridge.Editor.Nodes
         private static void SetupImageFill(FigmaImage figmaImage,Paint fill)
         {
             // Assign image fill, load from asset database
+            if (!ImportSessionCache.imageNameMap.TryGetValue(fill.imageRef, out var value))
+            {
+                return;
+            }
             figmaImage.sprite = AssetDatabase.LoadAssetAtPath<Sprite>(
-                    FigmaPaths.GetPathForImageFill(fill.imageRef));
+                    FigmaPaths.GetPathForImageFill(fill.imageRef, value));
 
             switch (fill.scaleMode)
             {
@@ -501,7 +506,7 @@ namespace UnityFigmaBridge.Editor.Nodes
 
             Vector4 borders = new Vector4(left, bottom, right, top);
             
-            var imagePath = FigmaPaths.GetPathForImageFill(fill.imageRef);
+            var imagePath = FigmaPaths.GetPathForImageFill(fill.imageRef, ImportSessionCache.imageNameMap[fill.imageRef]);
             var importer = (TextureImporter)AssetImporter.GetAtPath(imagePath);
 			if (importer == null)
             {

--- a/UnityFigmaBridge/Editor/UnityFigmaBridgeImporter.cs
+++ b/UnityFigmaBridge/Editor/UnityFigmaBridgeImporter.cs
@@ -67,6 +67,8 @@ namespace UnityFigmaBridge.Editor
         
         private static async void SyncAsync()
         {
+            ImportSessionCache.CacheClear();//キャッシュの削除
+            
             var requirementsMet = CheckRequirements();
             if (!requirementsMet) return;
             
@@ -140,6 +142,7 @@ namespace UnityFigmaBridge.Editor
             await ImportDocument(s_UnityFigmaBridgeSettings.FileId, figmaFile, pageNodeList);
             
             FigmaAssetGuidMapManager.SaveAllMap();
+            ImportSessionCache.CacheClear();
         }
 
         /// <summary>
@@ -371,6 +374,12 @@ namespace UnityFigmaBridge.Editor
             return null;
         }
 
+        /// <summary>
+        /// Figmaドキュメントのインポート
+        /// </summary>
+        /// <param name="fileId">FigmaファイルのID</param>
+        /// <param name="figmaFile">Figmaデータ</param>
+        /// <param name="downloadPageNodeList">ダウンロード対象のページノード一覧</param>
         private static async Task ImportDocument(string fileId, FigmaFile figmaFile, List<Node> downloadPageNodeList)
         {
             // Build a list of page IDs to download
@@ -449,6 +458,7 @@ namespace UnityFigmaBridge.Editor
             // Make sure that existing downloaded assets are in the correct format
             FigmaApiUtils.CheckExistingAssetProperties();
             
+            // 利用されているImageをピックして保持する
             // Track fills that are actually used. This is needed as FIGMA has a way of listing any bitmap used rather than active 
             var foundImageFills = FigmaDataUtils.GetAllImageFillIdsFromFile(figmaFile,downloadPageIdList);
             

--- a/UnityFigmaBridge/Editor/UnityFigmaBridgeImporter.cs
+++ b/UnityFigmaBridge/Editor/UnityFigmaBridgeImporter.cs
@@ -541,7 +541,7 @@ namespace UnityFigmaBridge.Editor
                 var screenController = figmaBridgeProcessData.PrototypeFlowController;
                 
                 // Find default flow start position
-                screenController.PrototypeFlowInitialScreenId =  FigmaDataUtils.FindPrototypeFlowStartScreenId(figmaBridgeProcessData.SourceFile);;
+                screenController.PrototypeFlowInitialScreenId =  FigmaDataUtils.FindPrototypeFlowStartScreenId(figmaBridgeProcessData.SourceFile);
 
                 if (screenController.ScreenParentTransform == null)
                     screenController.ScreenParentTransform=UnityUiUtils.CreateRectTransform("ScreenParentTransform",

--- a/UnityFigmaBridge/Editor/Utils/FigmaPaths.cs
+++ b/UnityFigmaBridge/Editor/Utils/FigmaPaths.cs
@@ -71,12 +71,12 @@ namespace UnityFigmaBridge.Editor.Utils
                 return imageAssetGuidMapData;
             }
         }
-        public static string GetPathForImageFill(string imageId)
+        public static string GetPathForImageFill(string imageId, string imageName)
         {
             var mapFilePath = ImageAssetGuidMapData?.GetAssetPath(imageId);
             if (string.IsNullOrEmpty(mapFilePath))
             {
-                return $"{FigmaPaths.FigmaImageFillFolder}/{imageId}.png";
+                return $"{FigmaPaths.FigmaImageFillFolder}/{imageName}.png";
             }
             return mapFilePath;
         }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "unity": "2021.3",
   "unityRelease": "0f1",
-  "version": "1.0.8+techcross.9",
+  "version": "1.0.8+techcross.10",
   "type": "library",
   "hideInEditor": false,
   "dependencies": {


### PR DESCRIPTION
画像名アドレスなのわかりにくいので、最初に行き当たったノード名に
ある程度自由にマテリアルがつけられるように、Figma独自の機能を利用していないものはUnityのImageを使うように
ノード単位のロードにしたときに、
インスタンス入れ替えのデフォルトFigmaコンポーネントが読み込むページで使われていないとエラー吐いてたので修正