### PR TITLE
フォント付け替え用のマーカー設定追加

### DIFF
--- a/UnityFigmaBridge/Editor/Nodes/FigmaNodeManager.cs
+++ b/UnityFigmaBridge/Editor/Nodes/FigmaNodeManager.cs
@@ -6,6 +6,7 @@ using UnityEngine.UI;
 using UnityFigmaBridge.Editor.Extension.ImportCache;
 using UnityFigmaBridge.Editor.FigmaApi;
 using UnityFigmaBridge.Editor.Fonts;
+using UnityFigmaBridge.Editor.Nodes.DataMarker;
 using UnityFigmaBridge.Editor.Utils;
 using UnityFigmaBridge.Runtime.UI;
 using Color = UnityEngine.Color;

--- a/UnityFigmaBridge/Editor/Nodes/FigmaNodeManager.cs
+++ b/UnityFigmaBridge/Editor/Nodes/FigmaNodeManager.cs
@@ -269,7 +269,10 @@ namespace UnityFigmaBridge.Editor.Nodes
                     // AASに含まないようにここではnullに
                     // text.fontMaterial = effectMaterialPreset;
                     text.fontMaterial = null;
-                    fontMarker.matName = effectMaterialPreset.name;
+                    if (effectMaterialPreset)
+                    {
+                        fontMarker.matName = effectMaterialPreset.name;
+                    }
                     
                     
                     break;

--- a/UnityFigmaBridge/Editor/Nodes/FigmaNodeManager.cs
+++ b/UnityFigmaBridge/Editor/Nodes/FigmaNodeManager.cs
@@ -121,14 +121,25 @@ namespace UnityFigmaBridge.Editor.Nodes
                     // Get the best fit TextMeshPro font this font (handled when document processed)
                     var text = nodeGameObject.GetComponent<TextMeshProUGUI>();
                     var matchingFontMapping = figmaImportProcessData.FontMap.GetFontMapping(node.style.fontFamily, node.style.fontWeight);
-                    text.font = matchingFontMapping.FontAsset;
+                    //　フォントアセットの設定　AASに含めない為に一旦設定しない
+                    // text.font = matchingFontMapping.FontAsset;
+                    text.font = null;
+                    var fontMarker = nodeGameObject.AddComponent<FontMarker>();
+                    
+                    // []がある場合は抜き取ってフォント名とする
+                    var fontName = NameCheckUtils.ExtractBracketContent(nodeGameObject.name);
+                    if (string.IsNullOrEmpty(fontName))
+                    {
+                        fontName = matchingFontMapping.FontAsset.name;
+                    }
+                    fontMarker.fontName = fontName;
                     
                     text.text = node.characters;
                     text.color = FigmaDataUtils.GetUnityFillColor(node.fills[0]);
                     text.fontSize = node.style.fontSize;
                     text.characterSpacing = -0.7f; // Figma handles spacing a little differently
                     text.raycastTarget = false;// 文字には基本当たり判定不要なので、初期値をfalseに
-                    
+                    text.lineSpacing = node.style.lineHeightPercent - 100f;// TMPの行間設定が 0基準なので、－100%する。
                     text.horizontalAlignment = node.style.textAlignHorizontal switch
                     {
                         TypeStyle.TextAlignHorizontal.LEFT => HorizontalAlignmentOptions.Left,
@@ -254,8 +265,10 @@ namespace UnityFigmaBridge.Editor.Nodes
                     }
                     var effectMaterialPreset = FontManager.GetEffectMaterialPreset(matchingFontMapping,
                         hasShadowEffect, shadowColor, shadowDistance, node.strokes.Length>0, outlineColor, outlineWidth);
-                    text.fontMaterial = effectMaterialPreset;
-
+                    // AASに含まないようにここではnullに
+                    // text.fontMaterial = effectMaterialPreset;
+                    text.fontMaterial = null;
+                    fontMarker.matName = effectMaterialPreset.name;
                     
                     
                     break;

--- a/UnityFigmaBridge/Editor/Utils/NameCheckUtils.cs
+++ b/UnityFigmaBridge/Editor/Utils/NameCheckUtils.cs
@@ -24,5 +24,33 @@ namespace UnityFigmaBridge.Editor.Utils
         {
             return node.name.Equals("DummyNode");
         }
+        
+        /// <summary>
+        /// []内を抜き取る
+        /// </summary>
+        public static string ExtractBracketContent(string input)
+        {
+            int level = 0;
+            int start = -1;
+
+            for (int i = 0; i < input.Length; i++)
+            {
+                if (input[i] == '[')
+                {
+                    if (level == 0) start = i + 1; // 外側の [ 開始位置
+                    level++;
+                }
+                else if (input[i] == ']')
+                {
+                    level--;
+                    if (level == 0 && start >= 0)
+                    {
+                        return input.Substring(start, i - start);
+                    }
+                }
+            }
+
+            return ""; // [] が見つからなかった場合
+        }
     }
 }

--- a/UnityFigmaBridge/Runtime/DataMarker.meta
+++ b/UnityFigmaBridge/Runtime/DataMarker.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: acca6af551484cc293cffd48a2400fc0
+timeCreated: 1754533808

--- a/UnityFigmaBridge/Runtime/DataMarker/FontMarker.cs
+++ b/UnityFigmaBridge/Runtime/DataMarker/FontMarker.cs
@@ -1,0 +1,13 @@
+using System;
+using TMPro;
+using UnityEngine;
+
+namespace UnityFigmaBridge.Editor.Nodes.DataMarker
+{
+    public class FontMarker : MonoBehaviour
+    {
+        // [SerializeField] private TMP_Text text;
+        public string fontName;
+        public string matName;
+    }
+}

--- a/UnityFigmaBridge/Runtime/DataMarker/FontMarker.cs.meta
+++ b/UnityFigmaBridge/Runtime/DataMarker/FontMarker.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1cb08592b81a4fa788e6935388d5f427
+timeCreated: 1759633312

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "unity": "2021.3",
   "unityRelease": "0f1",
-  "version": "1.0.8+techcross.12",
+  "version": "1.0.8+techcross.13",
   "type": "library",
   "hideInEditor": false,
   "dependencies": {


### PR DESCRIPTION
Addressablesで扱う際にフォントが取り込まれないようデフォルトにしつつ、戻せるようにマーカーを追加