### PR TITLE
【FigmaBridge改修】再Syncしたら作業内容が飛ぶことがあるのを修正する

### DIFF
--- a/UnityFigmaBridge/Editor/Components/ComponentManager.cs
+++ b/UnityFigmaBridge/Editor/Components/ComponentManager.cs
@@ -453,7 +453,7 @@ namespace UnityFigmaBridge.Editor.Components
             // 差分Syncの一致判定に使うため、最初にメタデータを更新する。
             SyncNodeMetadata(source, target);
             SyncComponents(source, target);
-            SyncChildren(source, target, node);
+            MergeNodeRecursive(source, target, node);
         }
         
          /// <summary>
@@ -605,7 +605,7 @@ namespace UnityFigmaBridge.Editor.Components
          /// 存在しない子があれば追加
          /// 存在していればコンポーネントのコピーを実施する
          /// </summary>
-        private static void SyncChildren(GameObject source, GameObject target, Node node)
+        private static void MergeNodeRecursive(GameObject source, GameObject target, Node node)
         {
             Debug.Log($" ==== 存在しない子があれば追加 Syncing children for source {source.name} and target {target.name} with node {node.name}");
             // 対象かソースが無効なら

--- a/UnityFigmaBridge/Editor/Components/ComponentManager.cs
+++ b/UnityFigmaBridge/Editor/Components/ComponentManager.cs
@@ -91,7 +91,7 @@ namespace UnityFigmaBridge.Editor.Components
         {
             if (node == null || nodeGameObject == null) return false;
 
-            var cacheMap = FigmaAssetGuidMapManager.CreateMap(FigmaAssetGuidMapManager.AssetType.Component);
+            var cacheMap = FigmaAssetGuidMapManager.CreateMap(FigmaAssetGuidMapManager.AssetType.Component);;
             var prefabAssetPath = cacheMap.GetAssetPath(node.id);
             if (string.IsNullOrEmpty(prefabAssetPath)) return false;
             if (!File.Exists(prefabAssetPath)) return false;
@@ -348,8 +348,27 @@ namespace UnityFigmaBridge.Editor.Components
             // インスタンスの場合、コンポーネントも確認する
             if (node.type == NodeType.INSTANCE)
             {
-                var componentNode = figmaImportProcessData.NodeLookupDictionary[node.componentId];
-                isSubstitution |= componentNode.customCondition.IsServerRenderNode();
+                if (string.IsNullOrEmpty(node.componentId))
+                {
+                    Debug.LogWarning($"[Instance] componentId が null/empty node={node.name}");
+                }
+                else if (!figmaImportProcessData.NodeLookupDictionary.TryGetValue(node.componentId, out var componentNode))
+                {
+                    Debug.LogWarning($"[Instance] componentNode が見つからない id={node.componentId} node={node.name}");
+                }
+                else if (componentNode == null)
+                {
+                    Debug.LogWarning($"[Instance] componentNode が null id={node.componentId} node={node.name}");
+                }
+                else if (componentNode.customCondition == null)
+                {
+                    Debug.LogWarning($"[Instance] customCondition が null id={node.componentId} node={node.name}");
+                }
+                else
+                {
+                    Debug.Log($"[Instance] substitution check id={node.componentId} node={node.name}");
+                    isSubstitution |= componentNode.customCondition.IsServerRenderNode();
+                }
             }
             if (!isSubstitution)
             {
@@ -520,47 +539,18 @@ namespace UnityFigmaBridge.Editor.Components
                  // 既存コンポーネントあり
                  if (targetComponent != null)
                  {
-                     SyncComponent(sourceComponent, targetComponent);
+                     //既存に上書きする
+                     Debug.Log($"[既存に上書きする] ");
+                     CopyComponent(sourceComponent,targetComponent);
                  }
                  else
                  {
                      // 無ければ追加だけする（安全）
                      Debug.Log($"[AddComponent] {type.Name} to {target.name}");
                      var added = target.AddComponent(type);
-                     SyncComponent(sourceComponent, added);
+                     CopyComponent(sourceComponent,added);
                  }
              }
-         }
-         
-         private static void SyncComponent(Component source, Component target)
-         {
-             if (source == null || target == null) return;
-
-             switch (target)
-             {
-                 // TextはFigmaを優先
-                 case TMP_Text targetText when source is TMP_Text sourceText:
-                     SyncTmpText(sourceText, targetText);
-                     return;
-
-                 // Imageは見た目だけ同期（spriteは保持）
-                 case Image targetImage when source is Image sourceImage:
-                     SyncImage(sourceImage, targetImage);
-                     return;
-             }
-
-             // それ以外は基本触らない（安全優先）
-             Debug.Log($"[SkipSync] {source.GetType().Name}");
-         }
-         
-         private static void SyncTmpText(TMP_Text source, TMP_Text target)
-         {
-             source.text = target.text;
-         }
-         
-         private static void SyncImage(Image source, Image target)
-         {
-             source.sprite = target.sprite;
          }
 
         /// <summary>
@@ -589,6 +579,7 @@ namespace UnityFigmaBridge.Editor.Components
                 return;
             }
             Debug.Log($"CopyComponent: {source.GetType().Name}　TargetComponent: {target.GetType().Name}");
+            //sourceをTargetにコピー
             EditorUtility.CopySerialized(source,target);
         }
         

--- a/UnityFigmaBridge/Editor/Components/ComponentManager.cs
+++ b/UnityFigmaBridge/Editor/Components/ComponentManager.cs
@@ -87,14 +87,10 @@ namespace UnityFigmaBridge.Editor.Components
         /// 既存Prefabが見つかり、差分マージを実行した場合は true。
         /// 対応するPrefabが存在しない、またはマージに失敗した場合は false。
         /// </returns>
-        public static bool TryMergeWithExistingPrefab(Node node, GameObject nodeGameObject)
+        public static bool TryMergeWithExistingPrefab(Node node, GameObject nodeGameObject,string path)
         {
             if (node == null || nodeGameObject == null) return false;
-
-            var cacheMap = FigmaAssetGuidMapManager.CreateMap(FigmaAssetGuidMapManager.AssetType.Component);
-            var prefabAssetPath = cacheMap.GetAssetPath(node.id);
-
-            return TryMergeFromPrefabPath(prefabAssetPath, node, nodeGameObject);
+            return TryMergeFromPrefabPath(path, node, nodeGameObject);
         }
         
         /// <summary>

--- a/UnityFigmaBridge/Editor/Components/ComponentManager.cs
+++ b/UnityFigmaBridge/Editor/Components/ComponentManager.cs
@@ -241,15 +241,12 @@ namespace UnityFigmaBridge.Editor.Components
                 var figmaNodeComponent = addedReplacementComponent.GetComponent<FigmaNodeObject>();
                 if (figmaNodeComponent == null)
                 {
-                    Debug.Log("FigmaNodeObject存在してないなら IDなしでNameだけ設定して追加");
-                    // FigmaNodeObject存在してないなら IDなしでNameだけ設定して追加する
+                    Debug.Log("FigmaNodeObject存在してないので追加");
                     figmaNodeComponent = addedReplacementComponent.AddComponent<FigmaNodeObject>();
                 }
-                else
-                {
-                    figmaNodeComponent.Initialise(placeholder.NodeId, placeholder.name);
-                }
-                
+                figmaNodeComponent.Initialise(placeholder.NodeId, placeholder.name);
+
+
                 // Copy transform order
                 addedReplacementComponent.transform.SetSiblingIndex(placeholder.transform.GetSiblingIndex()); // Put at same order
                 // Get the Node data for this component
@@ -678,6 +675,7 @@ namespace UnityFigmaBridge.Editor.Components
             typeof(RemoteComponentMarker),
             typeof(ButtonMarker),
             typeof(ToggleMarker),
+            typeof(FigmaFontSwitcher),
             
             // 以下は常にFigmaの設定の方が正なので上書きしない
             typeof(RectTransform),

--- a/UnityFigmaBridge/Editor/Components/ComponentManager.cs
+++ b/UnityFigmaBridge/Editor/Components/ComponentManager.cs
@@ -582,6 +582,7 @@ namespace UnityFigmaBridge.Editor.Components
 
         /// <summary>
         /// NodeId を優先し、取得できない場合のみ NodeName を使う。
+        /// id + name の複合キーだと名前変更で一致しなくなるので一旦ID優先で見る
         /// 前方一致の誤判定を避けるため prefix を固定する。
         /// </summary>
         private static string GetNodeSearchKey(string nodeId, string nodeName)

--- a/UnityFigmaBridge/Editor/Components/ComponentManager.cs
+++ b/UnityFigmaBridge/Editor/Components/ComponentManager.cs
@@ -510,8 +510,9 @@ namespace UnityFigmaBridge.Editor.Components
             Debug.Log($"==== コンポ―ネントと子を同期する SyncComponentsAndChildren called for source {source.name} and target {target.name} with node {node.name}");
             // Figma のノード情報を最新に保つ。
             // 既存オブジェクト(target)に source 側の NodeId / NodeName を反映する
-            ApplyNodeMetadataToExistingObject(source, target);
-            SyncComponents(source, target);
+            // ① Self を同期
+             SyncSelf(source, target);
+            // ② 子を同期
             MergeNodeRecursive(source, target, node);
         }
         
@@ -536,19 +537,16 @@ namespace UnityFigmaBridge.Editor.Components
                  var type = sourceComponent.GetType();
                  var targetComponent = targetComponents.FirstOrDefault(c => c.GetType() == type);
 
-                 // 既存コンポーネントあり
                  if (targetComponent != null)
                  {
-                     //既存に上書きする
-                     Debug.Log($"[既存に上書きする] ");
-                     CopyComponent(sourceComponent,targetComponent);
+                     Debug.Log("[既存に上書きする]");
+                     CopyComponent(sourceComponent, targetComponent, source.transform, target.transform);
                  }
                  else
                  {
-                     // 無ければ追加だけする（安全）
                      Debug.Log($"[AddComponent] {type.Name} to {target.name}");
                      var added = target.AddComponent(type);
-                     CopyComponent(sourceComponent,added);
+                     CopyComponent(sourceComponent, added, source.transform, target.transform);
                  }
              }
          }
@@ -559,14 +557,16 @@ namespace UnityFigmaBridge.Editor.Components
         /// 基本 EditorUtility.CopySerialized を利用
         /// 例外はこの関数内で定義
         /// </summary>
-        private static void CopyComponent(Component source, Component target)
+        private static void CopyComponent(Component source, Component target, Transform sourceRoot, Transform targetRoot)
         {
-            if(source == null || target == null) return;
+            if (source == null || target == null) return;
+
             // TMP_Text は文字列だけFigmaの内容を優先する。
             if (target is TMP_Text targetText)
             {
                 var message = targetText.text;
-                EditorUtility.CopySerialized(source,target);
+                EditorUtility.CopySerialized(source, target);
+                RemapInternalReferences(source, target, sourceRoot, targetRoot);
                 targetText.text = message;
                 return;
             }
@@ -574,39 +574,151 @@ namespace UnityFigmaBridge.Editor.Components
             if (target is Image img)
             {
                 var sprite = img.sprite;
-                EditorUtility.CopySerialized(source,target);
+                EditorUtility.CopySerialized(source, target);
+                RemapInternalReferences(source, target, sourceRoot, targetRoot);
                 img.sprite = sprite;
                 return;
             }
-            Debug.Log($"CopyComponent: {source.GetType().Name}　TargetComponent: {target.GetType().Name}");
+
+            Debug.Log($"CopyComponent: {source.GetType().Name} TargetComponent: {target.GetType().Name}");
             //sourceをTargetにコピー
-            EditorUtility.CopySerialized(source,target);
+            EditorUtility.CopySerialized(source, target);
+            // コピー後、source 側 subtree 内を指している参照を target 側 subtree の対応オブジェクトへ張り替える
+            RemapInternalReferences(source, target, sourceRoot, targetRoot);
         }
-        
+
         /// <summary>
-        /// source 側の Figma ノード識別情報を target に反映する
-        /// 差分 Sync 時の一致判定に使うため、既存オブジェクトの NodeId / NodeName を更新する
+        /// CopySerialized 後、source 側 subtree 内を指している参照を
+        /// target 側 subtree の対応オブジェクトへ張り替える
         /// </summary>
-        private static void ApplyNodeMetadataToExistingObject(GameObject source, GameObject target)
+        private static void RemapInternalReferences(Component source, Component target, Transform sourceRoot, Transform targetRoot)
         {
-            var sourceNodeObject = source.GetComponent<FigmaNodeObject>();
-            if (sourceNodeObject == null)
+            var so = new SerializedObject(target);
+            var prop = so.GetIterator();
+
+            var enterChildren = true;
+            while (prop.NextVisible(enterChildren))
             {
-                Debug.Log($"[NodeMetadata] source に FigmaNodeObject がないため仮で追加: {source.name}");
-                sourceNodeObject = EnsureNodeObject(source.transform);
-                sourceNodeObject.Initialise("",source.name);
+                enterChildren = true;
+
+                if (prop.propertyType != SerializedPropertyType.ObjectReference)
+                    continue;
+
+                var refObj = prop.objectReferenceValue;
+                if (refObj == null)
+                    continue;
+
+                // prefab内の子参照だけを再マップ対象にする
+                if (!(refObj is Component) && !(refObj is GameObject))
+                    continue;
+
+                var sourceTransform = GetReferencedTransform(refObj);
+                if (sourceTransform == null)
+                    continue;
+
+                // 今同期している source subtree 外の参照は触らない
+                if (!IsChildOf(sourceTransform, sourceRoot))
+                    continue;
+
+                var remapped = FindMatchingObjectInTarget(sourceTransform, sourceRoot, targetRoot, refObj.GetType());
+                if (remapped != null)
+                {
+                    prop.objectReferenceValue = remapped;
+                }
+                else
+                {
+                    Debug.LogWarning($"[Remap] failed: prop={prop.propertyPath}, ref={refObj.name}, type={refObj.GetType().Name}");
+                }
             }
 
-            var targetNodeObject = target.GetComponent<FigmaNodeObject>();
-            if (targetNodeObject == null)
-            {
-                targetNodeObject = target.AddComponent<FigmaNodeObject>();
-            }
-
-            Debug.Log($"[NodeMetadata] Apply NodeId={sourceNodeObject.NodeId}, NodeName={sourceNodeObject.NodeName} to target={target.name}");
-            targetNodeObject.Initialise(sourceNodeObject.NodeId, sourceNodeObject.NodeName);
+            so.ApplyModifiedPropertiesWithoutUndo();
         }
         
+        private static Object FindMatchingObjectInTarget(Transform sourceRef, Transform sourceRoot, Transform targetRoot, Type refType)
+        {
+            var relativePath = GetRelativePath(sourceRoot, sourceRef);
+            var targetTransform = FindByRelativePath(targetRoot, relativePath);
+
+            if (targetTransform == null)
+            {
+                Debug.LogWarning($"[Remap] target not found by path: {relativePath}");
+                return null;
+            }
+
+            if (refType == typeof(GameObject))
+                return targetTransform.gameObject;
+
+            if (refType == typeof(Transform))
+                return targetTransform;
+
+            if (refType == typeof(RectTransform))
+                return targetTransform as RectTransform;
+
+            if (typeof(Component).IsAssignableFrom(refType))
+                return targetTransform.GetComponent(refType);
+
+            return null;
+        }
+        
+        private static string GetRelativePath(Transform root, Transform target)
+        {
+            if (target == root) return string.Empty;
+
+            var stack = new Stack<string>();
+            var current = target;
+
+            while (current != null && current != root)
+            {
+                stack.Push(current.name);
+                current = current.parent;
+            }
+
+            return string.Join("/", stack);
+        }
+
+        private static Transform FindByRelativePath(Transform root, string path)
+        {
+            if (string.IsNullOrEmpty(path)) return root;
+            return root.Find(path);
+        }
+
+        private static Transform GetReferencedTransform(Object obj)
+        {
+            if (obj is GameObject go) return go.transform;
+            if (obj is Component comp) return comp.transform;
+            return null;
+        }
+
+        private static bool IsChildOf(Transform child, Transform root)
+        {
+            var current = child;
+            while (current != null)
+            {
+                if (current == root) return true;
+                current = current.parent;
+            }
+            return false;
+        }
+
+        private static void SyncSelf(GameObject source, GameObject target)
+        {
+            SyncNodeMetadataComponent(source, target);
+            SyncComponents(source, target);
+        }
+        
+        private static void SyncNodeMetadataComponent(GameObject source, GameObject target)
+        {
+            var sourceNodeObject = EnsureNodeObject(source.transform);
+            var targetNodeObject = EnsureNodeObject(target.transform);
+
+            Debug.Log(
+                $"[NodeMetadata] copy target({target.name}) -> source({source.name}) " +
+                $"NodeId={targetNodeObject.NodeId}, NodeName={targetNodeObject.NodeName}");
+
+            sourceNodeObject.Initialise(targetNodeObject.NodeId, targetNodeObject.NodeName);
+        }
+
+
         /// <summary>
         /// NodeId を優先し、取得できない場合のみ NodeName を使う。
         /// id + name の複合キーだと名前変更で一致しなくなるので一旦ID優先で見る
@@ -660,18 +772,17 @@ namespace UnityFigmaBridge.Editor.Components
         {
             var list = new List<SourceChildInfo>();            
             // 自身を登録
-            var selfNodeObj = EnsureNodeObject(source.transform);
-            var selfId = selfNodeObj.NodeId;
-            var selfName = string.IsNullOrEmpty(selfNodeObj.NodeName) ? source.name : selfNodeObj.NodeName;
-
-            list.Add(new SourceChildInfo
-            {
-                Source = source.transform,
-                Node = node,
-                Id = selfId,
-                Name = selfName
-            });
-
+            // var selfNodeObj = EnsureNodeObject(source.transform);
+            // var selfId = selfNodeObj.NodeId;
+            // var selfName = string.IsNullOrEmpty(selfNodeObj.NodeName) ? source.name : selfNodeObj.NodeName;
+            
+            // list.Add(new SourceChildInfo
+            //  {
+            //      Source = source.transform,
+            //      Node = node,
+            //      Id = selfId,
+            //      Name = selfName
+            // });
 
             //子を登録
             foreach (Transform child in source.transform)
@@ -737,9 +848,9 @@ namespace UnityFigmaBridge.Editor.Components
                 {
                     Debug.Log($"[既存と同期] {s.Source.name}");
                     //IDの更新
-                    var sourceNode = s.Source.GetComponent<FigmaNodeObject>();
-                    var targetNode = s.Target.GetComponent<FigmaNodeObject>();
-                    sourceNode.Initialise(targetNode.NodeId,targetNode.NodeName);
+                    // var sourceNode = s.Source.GetComponent<FigmaNodeObject>();
+                    // var targetNode = s.Target.GetComponent<FigmaNodeObject>();
+                    // sourceNode.Initialise(targetNode.NodeId,targetNode.NodeName);
                     SyncComponentsAndChildren(s.Source.gameObject, s.Target.gameObject, s.Node);
                 }
                 else
@@ -764,7 +875,8 @@ namespace UnityFigmaBridge.Editor.Components
         private static List<Transform> GetChildren(GameObject obj)
         {
             var list = new List<Transform>();
-            foreach (Transform t in obj.transform) list.Add(t);
+            foreach (Transform t in obj.transform)
+                list.Add(t);
             return list;
         }
 

--- a/UnityFigmaBridge/Editor/Components/ComponentManager.cs
+++ b/UnityFigmaBridge/Editor/Components/ComponentManager.cs
@@ -490,8 +490,8 @@ namespace UnityFigmaBridge.Editor.Components
         {
             Debug.Log($"==== コンポ―ネントと子を同期する SyncComponentsAndChildren called for source {source.name} and target {target.name} with node {node.name}");
             // Figma のノード情報を最新に保つ。
-            // 差分Syncの一致判定に使うため、最初にメタデータを更新する。
-            SyncNodeMetadata(source, target);
+            // 既存オブジェクト(target)に source 側の NodeId / NodeName を反映する
+            ApplyNodeMetadataToExistingObject(source, target);
             SyncComponents(source, target);
             MergeNodeRecursive(source, target, node);
         }
@@ -500,55 +500,68 @@ namespace UnityFigmaBridge.Editor.Components
          /// targetに存在しないコンポーネントを追加(マーカー系を除く)、
          /// 既に存在するコンポーネントはデータをコピー(CopySerialized)する
          /// </summary>
-        public static void SyncComponents(GameObject source, GameObject target)
-        {
-            Debug.Log($"==== コンポーネントを追加 SyncComponents called for source {source.name} and target {target.name}");
-            List<Component> sourceComponents = new List<Component>(
-                source.GetComponents<Component>()
-                    .Where(c => !SkipCopyComponentTypes.Contains(c.GetType())));// コピー対象でないコンポーネントを除く
-            List<Component> targetComponents = new List<Component>(target.GetComponents<Component>());
+         public static void SyncComponents(GameObject source, GameObject target)
+         {
+             Debug.Log($"==== SyncComponents source={source.name} target={target.name}");
 
-            foreach (var comp in targetComponents)
-            {
-                Component deleteItem = null;
-                var type1 = comp.GetType();
-                
-                foreach (var comp2 in sourceComponents)
-                {
-                    // 合致するコンポーネントがあったら、データをコピーして終了
-                    if (type1 == comp2.GetType())
-                    {
-                        deleteItem = comp2;
-                        CopyComponent(comp2,comp);
-                        break;
-                    }
-                }
+             var sourceComponents = source.GetComponents<Component>()
+                 .Where(c => c != null && !SkipCopyComponentTypes.Contains(c.GetType()))
+                 .ToList();
 
-                // 合致したものはリストから削除する
-                if (deleteItem != null)
-                {
-                    sourceComponents.Remove(deleteItem);
-                }
-            }
-            // 全て見た後に残っているものがあれば追加する
-            foreach (var comp2 in sourceComponents)
-            {
-                Type type = comp2.GetType();
-                Debug.Log($" 既存のものを落としてきたFigmaに入れる add new component: {type.Name} to {target.name}");
-                var component = target.AddComponent(type);
-                if (component == null)
-                {
-                    if ((type == typeof(FigmaImage) || type == typeof(Image)) &&
-                        target.GetComponent<Image>() is { } img)//nullチェック
-                    {
-                        Debug.Log($"  reuse Image component and copy image values: {type.Name}");
-                        img.CopyImage((Image)comp2, false);// SourceImageはFigmaが正なのでコピーしない
-                        continue;
-                    }
-                }
-                CopyComponent(comp2,component);
-            }
-        }
+             var targetComponents = target.GetComponents<Component>()
+                 .Where(c => c != null)
+                 .ToList();
+
+             foreach (var sourceComponent in sourceComponents)
+             {
+                 var type = sourceComponent.GetType();
+                 var targetComponent = targetComponents.FirstOrDefault(c => c.GetType() == type);
+
+                 // 既存コンポーネントあり
+                 if (targetComponent != null)
+                 {
+                     SyncComponent(sourceComponent, targetComponent);
+                 }
+                 else
+                 {
+                     // 無ければ追加だけする（安全）
+                     Debug.Log($"[AddComponent] {type.Name} to {target.name}");
+                     var added = target.AddComponent(type);
+                     SyncComponent(sourceComponent, added);
+                 }
+             }
+         }
+         
+         private static void SyncComponent(Component source, Component target)
+         {
+             if (source == null || target == null) return;
+
+             switch (target)
+             {
+                 // TextはFigmaを優先
+                 case TMP_Text targetText when source is TMP_Text sourceText:
+                     SyncTmpText(sourceText, targetText);
+                     return;
+
+                 // Imageは見た目だけ同期（spriteは保持）
+                 case Image targetImage when source is Image sourceImage:
+                     SyncImage(sourceImage, targetImage);
+                     return;
+             }
+
+             // それ以外は基本触らない（安全優先）
+             Debug.Log($"[SkipSync] {source.GetType().Name}");
+         }
+         
+         private static void SyncTmpText(TMP_Text source, TMP_Text target)
+         {
+             source.text = target.text;
+         }
+         
+         private static void SyncImage(Image source, Image target)
+         {
+             source.sprite = target.sprite;
+         }
 
         /// <summary>
         /// コンポーネントのコピー処理
@@ -580,15 +593,17 @@ namespace UnityFigmaBridge.Editor.Components
         }
         
         /// <summary>
-        /// Figmaノードのメタデータを target に反映する。
-        /// NodeId / NodeName を更新して次回Sync時の一致精度を上げる。
+        /// source 側の Figma ノード識別情報を target に反映する
+        /// 差分 Sync 時の一致判定に使うため、既存オブジェクトの NodeId / NodeName を更新する
         /// </summary>
-        private static void SyncNodeMetadata(GameObject source, GameObject target)
+        private static void ApplyNodeMetadataToExistingObject(GameObject source, GameObject target)
         {
             var sourceNodeObject = source.GetComponent<FigmaNodeObject>();
             if (sourceNodeObject == null)
             {
-                return;
+                Debug.Log($"[NodeMetadata] source に FigmaNodeObject がないため仮で追加: {source.name}");
+                sourceNodeObject = EnsureNodeObject(source.transform);
+                sourceNodeObject.Initialise("",source.name);
             }
 
             var targetNodeObject = target.GetComponent<FigmaNodeObject>();
@@ -597,6 +612,7 @@ namespace UnityFigmaBridge.Editor.Components
                 targetNodeObject = target.AddComponent<FigmaNodeObject>();
             }
 
+            Debug.Log($"[NodeMetadata] Apply NodeId={sourceNodeObject.NodeId}, NodeName={sourceNodeObject.NodeName} to target={target.name}");
             targetNodeObject.Initialise(sourceNodeObject.NodeId, sourceNodeObject.NodeName);
         }
         
@@ -649,10 +665,20 @@ namespace UnityFigmaBridge.Editor.Components
             RemoveUnusedTargets(remainingTargets);
         }
         
-        private static List<SourceChildInfo> BuildSourceChildInfos(GameObject source, Node node)
+        private static List<SourceChildInfo> BuildSourceChildInfos(GameObject source,  Node node)
         {
+            //自身を登録
             var list = new List<SourceChildInfo>();
-
+            EnsureNodeObject(source.transform);
+            list.Add(new SourceChildInfo
+            {
+                Source = source.transform,
+                Node = node,
+                Id = id,
+                Name = name
+            });
+            
+            //子を登録
             foreach (Transform child in source.transform)
             {
                 var nodeObj = EnsureNodeObject(child);
@@ -715,6 +741,10 @@ namespace UnityFigmaBridge.Editor.Components
                 if (s.Target != null)
                 {
                     Debug.Log($"[既存と同期] {s.Source.name}");
+                    //IDの更新
+                    var sourceNode = s.Source.GetComponent<FigmaNodeObject>();
+                    var targetNode = s.Target.GetComponent<FigmaNodeObject>();
+                    sourceNode.Initialise(targetNode.NodeId,targetNode.NodeName);
                     SyncComponentsAndChildren(s.Source.gameObject, s.Target.gameObject, s.Node);
                 }
                 else

--- a/UnityFigmaBridge/Editor/Components/ComponentManager.cs
+++ b/UnityFigmaBridge/Editor/Components/ComponentManager.cs
@@ -241,7 +241,9 @@ namespace UnityFigmaBridge.Editor.Components
                 var figmaNodeComponent = addedReplacementComponent.GetComponent<FigmaNodeObject>();
                 if (figmaNodeComponent == null)
                 {
-                    Debug.LogWarning("No FigmaNodeObject on component prefab");
+                    Debug.Log("FigmaNodeObject存在してないなら IDなしでNameだけ設定して追加");
+                    // FigmaNodeObject存在してないなら IDなしでNameだけ設定して追加する
+                    figmaNodeComponent = addedReplacementComponent.AddComponent<FigmaNodeObject>();
                 }
                 else
                 {

--- a/UnityFigmaBridge/Editor/Components/ComponentManager.cs
+++ b/UnityFigmaBridge/Editor/Components/ComponentManager.cs
@@ -100,14 +100,27 @@ namespace UnityFigmaBridge.Editor.Components
             {
                 prefabAssetPath = FigmaPaths.GetPathForComponentPrefab(nodeName,componentCount);
             }
-            // 元となるプレハブが存在する場合はバックアップを取る
+        
+            // 既存Prefabがある場合は、Unity側変更を今回生成物へ差分マージする
             if (File.Exists(prefabAssetPath))
             {
-                var backupPath = FigmaPaths.MakeBackupPath(prefabAssetPath);
-                Directory.CreateDirectory(Path.GetDirectoryName(backupPath) ?? string.Empty);
-                AssetDatabase.DeleteAsset(backupPath);
-                AssetDatabase.CopyAsset(prefabAssetPath, backupPath);
+                var existingPrefabContents = PrefabUtility.LoadPrefabContents(prefabAssetPath);
+                try
+                {
+                    Debug.Log($"==== 既存Prefabとの差分マージ開始: {prefabAssetPath}");
+
+                    SyncComponentsAndChildren(existingPrefabContents, nodeGameObject, node);
+                }
+                catch (Exception e)
+                {
+                    Debug.LogWarning($"既存Prefabとの差分マージに失敗: {prefabAssetPath}\n{e}");
+                }
+                finally
+                {
+                    PrefabUtility.UnloadPrefabContents(existingPrefabContents);
+                }
             }
+
             
             var componentPrefab = PrefabUtility.SaveAsPrefabAssetAndConnect(nodeGameObject, prefabAssetPath, InteractionMode.UserAction);
             figmaImportProcessData.ComponentData.RegisterComponentPrefab(node.id,componentPrefab);
@@ -266,20 +279,6 @@ namespace UnityFigmaBridge.Editor.Components
             // Save prefab and all changes
             try
             {
-                var backupPath = FigmaPaths.MakeBackupPath(assetPath);
-                var backupPrefab  = AssetDatabase.LoadAssetAtPath<GameObject>(backupPath);
-                if (backupPrefab)
-                {
-                    var figmaNodeComponent = prefabContents.GetComponent<FigmaNodeObject>();
-                    if (figmaNodeComponent)
-                    {
-                        var componentRootNode = figmaImportProcessData.NodeLookupDictionary[figmaNodeComponent.NodeId];
-                    
-                        SyncComponentsAndChildren(backupPrefab , prefabContents, componentRootNode);
-                    }
-                }
-                
-                
                 // We might have issue with nested elements so need try catch loop
                 // TODO - Check for recurisve nested components
                 PrefabUtility.SaveAsPrefabAsset(prefabContents, assetPath);
@@ -447,8 +446,9 @@ namespace UnityFigmaBridge.Editor.Components
         /// <summary>
         /// コンポ―ネントと子を同期する
         /// </summary>
-        public static void SyncComponentsAndChildren(GameObject source, GameObject target, Node node)
+        private static void SyncComponentsAndChildren(GameObject source, GameObject target, Node node)
         {
+            Debug.Log($"==== コンポ―ネントと子を同期する SyncComponentsAndChildren called for source {source.name} and target {target.name} with node {node.name}");
             // Figma のノード情報を最新に保つ。
             // 差分Syncの一致判定に使うため、最初にメタデータを更新する。
             SyncNodeMetadata(source, target);
@@ -462,6 +462,7 @@ namespace UnityFigmaBridge.Editor.Components
          /// </summary>
         public static void SyncComponents(GameObject source, GameObject target)
         {
+            Debug.Log($"==== コンポーネントを追加 SyncComponents called for source {source.name} and target {target.name}");
             List<Component> sourceComponents = new List<Component>(
                 source.GetComponents<Component>()
                     .Where(c => !SkipCopyComponentTypes.Contains(c.GetType())));// コピー対象でないコンポーネントを除く

--- a/UnityFigmaBridge/Editor/Components/ComponentManager.cs
+++ b/UnityFigmaBridge/Editor/Components/ComponentManager.cs
@@ -667,17 +667,21 @@ namespace UnityFigmaBridge.Editor.Components
         
         private static List<SourceChildInfo> BuildSourceChildInfos(GameObject source,  Node node)
         {
-            //自身を登録
-            var list = new List<SourceChildInfo>();
-            EnsureNodeObject(source.transform);
+            var list = new List<SourceChildInfo>();            
+            // 自身を登録
+            var selfNodeObj = EnsureNodeObject(source.transform);
+            var selfId = selfNodeObj.NodeId;
+            var selfName = string.IsNullOrEmpty(selfNodeObj.NodeName) ? source.name : selfNodeObj.NodeName;
+
             list.Add(new SourceChildInfo
             {
                 Source = source.transform,
                 Node = node,
-                Id = id,
-                Name = name
+                Id = selfId,
+                Name = selfName
             });
-            
+
+
             //子を登録
             foreach (Transform child in source.transform)
             {

--- a/UnityFigmaBridge/Editor/Components/ComponentManager.cs
+++ b/UnityFigmaBridge/Editor/Components/ComponentManager.cs
@@ -847,10 +847,6 @@ namespace UnityFigmaBridge.Editor.Components
                 if (s.Target != null)
                 {
                     Debug.Log($"[既存と同期] {s.Source.name}");
-                    //IDの更新
-                    // var sourceNode = s.Source.GetComponent<FigmaNodeObject>();
-                    // var targetNode = s.Target.GetComponent<FigmaNodeObject>();
-                    // sourceNode.Initialise(targetNode.NodeId,targetNode.NodeName);
                     SyncComponentsAndChildren(s.Source.gameObject, s.Target.gameObject, s.Node);
                     SyncComponentsAndChildren(s.Source.gameObject, s.Target.gameObject, s.Node, fixedSourceRoot, fixedTargetRoot);
                 }
@@ -858,7 +854,6 @@ namespace UnityFigmaBridge.Editor.Components
                 {
                     var copy = Object.Instantiate(s.Source.gameObject, target.transform, false);
                     copy.name = s.Source.name;
-
                     Debug.Log($"[既存にないので作成 Create] {copy.name}");
                 }
             }

--- a/UnityFigmaBridge/Editor/Components/ComponentManager.cs
+++ b/UnityFigmaBridge/Editor/Components/ComponentManager.cs
@@ -137,7 +137,15 @@ namespace UnityFigmaBridge.Editor.Components
             try
             {
                 Debug.Log($"[PrefabMerge] merge existing prefab path={prefabAssetPath}, node={node.name}, type={node.type}, id={node.id}");
-                SyncComponentsAndChildren(existingPrefabContents, nodeGameObject, node);
+                
+                // 参照remapの基準rootはマージ対象のてっぺんで固定する。
+                // source=既存Prefabルート / target=今回生成ルートを必ず渡す。
+                SyncComponentsAndChildren(
+                    existingPrefabContents,
+                    nodeGameObject,
+                    node,
+                    existingPrefabContents.transform,
+                    nodeGameObject.transform);
                 return true;
             }
             catch (Exception e)
@@ -492,23 +500,44 @@ namespace UnityFigmaBridge.Editor.Components
         /// <param name="node">Figmaノード情報</param>
         private static void SyncComponentsAndChildren(GameObject source, GameObject target, Node node)
         {
+            if (source == null || target == null)
+            {
+                return;
+            }
+
+            // 差分同期の基準rootは最初の呼び出し時に固定する。
+            // 子の再帰に入ってもこのrootを使い続けることで参照先のズレを防ぐ。
+            SyncComponentsAndChildren(source, target, node, source.transform, target.transform);
+        }
+
+        /// <summary>
+        /// 参照remapに使うrootを固定したまま再帰同期する。
+        /// </summary>
+        private static void SyncComponentsAndChildren(
+            GameObject source,
+            GameObject target,
+            Node node,
+            Transform fixedSourceRoot,
+            Transform fixedTargetRoot)
+        {
+            if (source == null || target == null)
+            {
+                return;
+            }
             Debug.Log($"==== コンポ―ネントと子を同期する SyncComponentsAndChildren called for source {source.name} and target {target.name} with node {node.name}");
             // Figma のノード情報を最新に保つ。
-            // 既存オブジェクト(target)に source 側の NodeId / NodeName を反映する
-            // ① Self を同期
-             SyncSelf(source, target);
-            // ② 子を同期
-            MergeNodeRecursive(source, target, node);
+            // 既存オブジェクト(target)に source 側の NodeId / NodeName を反映する。
+            SyncSelf(source, target, fixedSourceRoot, fixedTargetRoot);
+            // 子同期でもrootは固定のまま渡す。
+            MergeNodeRecursive(source, target, node, fixedSourceRoot, fixedTargetRoot);
         }
         
          /// <summary>
          /// targetに存在しないコンポーネントを追加(マーカー系を除く)、
          /// 既に存在するコンポーネントはデータをコピー(CopySerialized)する
          /// </summary>
-         public static void SyncComponents(GameObject source, GameObject target)
+         public static void SyncComponents(GameObject source, GameObject target, Transform fixedSourceRoot, Transform fixedTargetRoot)
          {
-             Debug.Log($"==== SyncComponents source={source.name} target={target.name}");
-
              var sourceComponents = source.GetComponents<Component>()
                  .Where(c => c != null && !SkipCopyComponentTypes.Contains(c.GetType()))
                  .ToList();
@@ -524,18 +553,30 @@ namespace UnityFigmaBridge.Editor.Components
 
                  if (targetComponent != null)
                  {
-                     Debug.Log("[既存に上書きする]");
-                     CopyComponent(sourceComponent, targetComponent, source.transform, target.transform);
+                     CopyComponent(sourceComponent, targetComponent, fixedSourceRoot, fixedTargetRoot);
                  }
                  else
                  {
-                     Debug.Log($"[AddComponent] {type.Name} to {target.name}");
                      var added = target.AddComponent(type);
-                     CopyComponent(sourceComponent, added, source.transform, target.transform);
+                     CopyComponent(sourceComponent, added, fixedSourceRoot, fixedTargetRoot);
                  }
              }
          }
 
+         /// <summary>
+         /// 既存呼び出し互換用。root指定なしの場合は自身をrootとして同期する。
+         /// </summary>
+         public static void SyncComponents(GameObject source, GameObject target)
+         {
+             if (source == null || target == null)
+             {
+                 return;
+             }
+
+             SyncComponents(source, target, source.transform, target.transform);
+         }
+         
+         
         /// <summary>
         /// コンポーネントのコピー処理
         /// 既存PrefabのComponentをDLしたオブジェクトへ上書きする
@@ -685,10 +726,10 @@ namespace UnityFigmaBridge.Editor.Components
             return false;
         }
 
-        private static void SyncSelf(GameObject source, GameObject target)
+        private static void SyncSelf(GameObject source, GameObject target, Transform fixedSourceRoot, Transform fixedTargetRoot)
         {
             SyncNodeMetadataComponent(source, target);
-            SyncComponents(source, target);
+            SyncComponents(source, target, fixedSourceRoot, fixedTargetRoot);
         }
         
         private static void SyncNodeMetadataComponent(GameObject source, GameObject target)
@@ -729,7 +770,7 @@ namespace UnityFigmaBridge.Editor.Components
         /// 存在していればコンポーネントのコピーを実施する
         /// 新規Figma に存在せず 既存オブジェクト にだけ存在する子は削除する
         /// </summary>
-        private static void MergeNodeRecursive(GameObject source, GameObject target, Node node)
+        private static void MergeNodeRecursive(GameObject source, GameObject target, Node node, Transform fixedSourceRoot, Transform fixedTargetRoot)
         {
             Debug.Log($"[Merge] {source.name} -> {target.name}");
 
@@ -747,7 +788,7 @@ namespace UnityFigmaBridge.Editor.Components
             MatchByName(sourceInfos, remainingTargets);
 
             // ③ 既存と同じを同期 or 新規追加
-            ApplyOrCreate(sourceInfos, target);
+            ApplyOrCreate(sourceInfos, target, fixedSourceRoot, fixedTargetRoot);
 
             // ④ 余った既存オブジェクト削除
             RemoveUnusedTargets(remainingTargets);
@@ -825,7 +866,7 @@ namespace UnityFigmaBridge.Editor.Components
             }
         }
 
-        private static void ApplyOrCreate(List<SourceChildInfo> sources, GameObject target)
+        private static void ApplyOrCreate(List<SourceChildInfo> sources, GameObject target, Transform fixedSourceRoot, Transform fixedTargetRoot)
         {
             foreach (var s in sources)
             {
@@ -837,6 +878,7 @@ namespace UnityFigmaBridge.Editor.Components
                     // var targetNode = s.Target.GetComponent<FigmaNodeObject>();
                     // sourceNode.Initialise(targetNode.NodeId,targetNode.NodeName);
                     SyncComponentsAndChildren(s.Source.gameObject, s.Target.gameObject, s.Node);
+                    SyncComponentsAndChildren(s.Source.gameObject, s.Target.gameObject, s.Node, fixedSourceRoot, fixedTargetRoot);
                 }
                 else
                 {

--- a/UnityFigmaBridge/Editor/Components/ComponentManager.cs
+++ b/UnityFigmaBridge/Editor/Components/ComponentManager.cs
@@ -534,7 +534,7 @@ namespace UnityFigmaBridge.Editor.Components
             foreach (var comp2 in sourceComponents)
             {
                 Type type = comp2.GetType();
-                Debug.Log($"  add new component: {type.Name} to {target.name}");
+                Debug.Log($" 既存のものを落としてきたFigmaに入れる   add new component: {type.Name} to {target.name}");
                 var component = target.AddComponent(type);
                 if (component == null)
                 {
@@ -588,6 +588,7 @@ namespace UnityFigmaBridge.Editor.Components
             var sourceNodeObject = source.GetComponent<FigmaNodeObject>();
             if (sourceNodeObject == null)
             {
+                Debug.Log("SyncNodeMetadata 既存にない");
                 return;
             }
 

--- a/UnityFigmaBridge/Editor/Components/ComponentManager.cs
+++ b/UnityFigmaBridge/Editor/Components/ComponentManager.cs
@@ -116,6 +116,28 @@ namespace UnityFigmaBridge.Editor.Components
                 PrefabUtility.UnloadPrefabContents(existingPrefabContents);
             }
         }
+
+        /// <summary>
+        /// 指定ノードの既存Prefabを検索するためのAssetTypeを返す。
+        /// 対応する管理種別がないノードは null を返す。
+        /// </summary>
+        private static FigmaAssetGuidMapManager.AssetType? GetAssetTypeForMergeTarget(Node node)
+        {
+            if (node == null) return null;
+
+            switch (node.type)
+            {
+                case NodeType.COMPONENT:
+                case NodeType.COMPONENT_SET:
+                    return FigmaAssetGuidMapManager.AssetType.Component;
+                case NodeType.FRAME:
+                    return FigmaAssetGuidMapManager.AssetType.Screen;
+                case NodeType.CANVAS:
+                    return FigmaAssetGuidMapManager.AssetType.Page;
+                default:
+                    return null;
+            }
+        }
         
         /// <summary>
         /// 生成済みのノードからコンポーネントPrefabを作成する

--- a/UnityFigmaBridge/Editor/Components/ComponentManager.cs
+++ b/UnityFigmaBridge/Editor/Components/ComponentManager.cs
@@ -76,13 +76,13 @@ namespace UnityFigmaBridge.Editor.Components
             PrefabUtility.UnloadPrefabContents(prefabContents);
         }
         
-        
         /// <summary>
-        /// Creates a component prefab from a given generated node
+        /// 生成済みのノードからコンポーネントPrefabを作成する
         /// </summary>
-        /// <param name="node"></param>
-        /// <param name="nodeGameObject"></param>
-        /// <param name="figmaImportProcessData"></param>
+        /// <param name="node">元となるFigmaノード</param>
+        /// <param name="parentNode">親ノード</param>
+        /// <param name="nodeGameObject">生成されたGameObject</param>
+        /// <param name="figmaImportProcessData">インポート処理で使用するデータ</param>
         public static void GenerateComponentAssetFromNode(Node node, Node parentNode, GameObject nodeGameObject, FigmaImportProcessData figmaImportProcessData)
         {
             // 外部コンポーネントだった場合は無視
@@ -445,6 +445,9 @@ namespace UnityFigmaBridge.Editor.Components
         /// <summary>
         /// コンポ―ネントと子を同期する
         /// </summary>
+        /// <param name="source">既存Prefabのオブジェクト</param>
+        /// <param name="target">今回生成されたオブジェクト</param>
+        /// <param name="node">Figmaノード情報</param>
         private static void SyncComponentsAndChildren(GameObject source, GameObject target, Node node)
         {
             Debug.Log($"==== コンポ―ネントと子を同期する SyncComponentsAndChildren called for source {source.name} and target {target.name} with node {node.name}");
@@ -507,14 +510,23 @@ namespace UnityFigmaBridge.Editor.Components
             }
         }
 
-         /// <summary>
-         /// コンポーネントのコピー処理
-         /// 基本 EditorUtility.CopySerialized を利用
-         /// 例外はこの関数内で定義
-         /// </summary>
+        /// <summary>
+        /// コンポーネントのコピー処理
+        /// 既存PrefabのComponentをDLしたオブジェクトへ上書きする
+        /// 基本 EditorUtility.CopySerialized を利用
+        /// 例外はこの関数内で定義
+        /// </summary>
         private static void CopyComponent(Component source, Component target)
         {
             if(source == null || target == null) return;
+            // TMP_Text は文字列だけFigmaの内容を優先する。
+            if (target is TMP_Text targetText)
+            {
+                var message = targetText.text;
+                EditorUtility.CopySerialized(source,target);
+                targetText.text = message;
+                return;
+            }
             // imageの場合、画像は最新のものに更新する
             if (target is Image img)
             {
@@ -675,11 +687,9 @@ namespace UnityFigmaBridge.Editor.Components
             typeof(RemoteComponentMarker),
             typeof(ButtonMarker),
             typeof(ToggleMarker),
-            typeof(FigmaFontSwitcher),
             
             // 以下は常にFigmaの設定の方が正なので上書きしない
             typeof(RectTransform),
-            typeof(TMP_Text),
             typeof(LayoutElement),
             typeof(LayoutGroup),
         };

--- a/UnityFigmaBridge/Editor/Components/ComponentManager.cs
+++ b/UnityFigmaBridge/Editor/Components/ComponentManager.cs
@@ -23,57 +23,6 @@ namespace UnityFigmaBridge.Editor.Components
 {
     public static class ComponentManager
     {
-       /// <summary>
-       /// Remove component placeholders that are used to mark instantiation locations
-       /// </summary>
-       /// <param name="figmaImportProcessData"></param>
-        public static void RemoveAllTemporaryNodeComponents(FigmaImportProcessData figmaImportProcessData)
-       {
-           // Remove from components (nested)
-            foreach (var componentPrefab in figmaImportProcessData.ComponentData.AllComponentPrefabs)
-                RemoveTemporaryNodeComponents(componentPrefab);
-            
-            // Remove from screens
-            foreach (var framePrefab in figmaImportProcessData.ScreenPrefabs.Where(framePrefab => framePrefab!=null))
-            {
-                RemoveTemporaryNodeComponents(framePrefab);
-            }
-            // Remove from pages
-            foreach (var pagePrefab in figmaImportProcessData.PagePrefabs.Where(pagePrefab => pagePrefab!=null))
-            {
-                RemoveTemporaryNodeComponents(pagePrefab);
-            }
-       }
-
-        /// <summary>
-        /// Remove all component placeholders from a given prefab object (could be flowScreen or component)
-        /// </summary>
-        /// <param name="sourcePrefab"></param>
-        private static void RemoveTemporaryNodeComponents(GameObject sourcePrefab)
-        {
-            var assetPath = AssetDatabase.GetAssetPath(sourcePrefab);
-            var prefabContents = PrefabUtility.LoadPrefabContents(assetPath);
-
-            // 差分Syncに使う FigmaNodeObject は残し、プレースホルダーマーカーだけ削除する。
-            // 再生成ではなく差分反映するため、NodeId と NodeName は維持する。
-            var allComponentMarkers = prefabContents.GetComponentsInChildren<FigmaComponentNodeMarker>(true);
-            foreach (var marker in allComponentMarkers)
-            {
-                Object.DestroyImmediate(marker);
-            }
-
-            var allSwapMarkers = prefabContents.GetComponentsInChildren<InstanceSwapMarker>(true);
-            foreach (var swapMarker in allSwapMarkers)
-            {
-                Object.DestroyImmediate(swapMarker);
-            }
-
-            // Save
-            PrefabUtility.SaveAsPrefabAsset(prefabContents, assetPath);
-            // Unload
-            PrefabUtility.UnloadPrefabContents(prefabContents);
-        }
-
         /// <returns>
         /// 既存Prefabが見つかり、差分マージを実行した場合は true。
         /// 対応するPrefabが存在しない、またはマージに失敗した場合は false。
@@ -584,18 +533,22 @@ namespace UnityFigmaBridge.Editor.Components
             if (target is TMP_Text targetText)
             {
                 var message = targetText.text;
+                var material = targetText.material;
                 EditorUtility.CopySerialized(source, target);
                 RemapInternalReferences(source, target, sourceRoot, targetRoot);
                 targetText.text = message;
+                targetText.material = material;
                 return;
             }
             // imageの場合、画像は最新のものに更新する
             if (target is Image img)
             {
                 var sprite = img.sprite;
+                var material = img.material;
                 EditorUtility.CopySerialized(source, target);
                 RemapInternalReferences(source, target, sourceRoot, targetRoot);
                 img.sprite = sprite;
+                img.material = material;
                 return;
             }
 

--- a/UnityFigmaBridge/Editor/Components/ComponentManager.cs
+++ b/UnityFigmaBridge/Editor/Components/ComponentManager.cs
@@ -91,7 +91,10 @@ namespace UnityFigmaBridge.Editor.Components
         {
             if (node == null || nodeGameObject == null) return false;
 
-            var cacheMap = FigmaAssetGuidMapManager.CreateMap(FigmaAssetGuidMapManager.AssetType.Component);
+            var assetType = GetAssetTypeForMergeTarget(node);
+            if (assetType == null) return false;
+
+            var cacheMap = FigmaAssetGuidMapManager.CreateMap(assetType.Value);
             var prefabAssetPath = cacheMap.GetAssetPath(node.id);
             if (string.IsNullOrEmpty(prefabAssetPath)) return false;
             if (!File.Exists(prefabAssetPath)) return false;
@@ -99,7 +102,7 @@ namespace UnityFigmaBridge.Editor.Components
             var existingPrefabContents = PrefabUtility.LoadPrefabContents(prefabAssetPath);
             try
             {
-                Debug.Log($"[PrefabMerge] merge existing prefab path={prefabAssetPath}, node={node.name}, type={node.type}, id={node.id}");
+                Debug.Log($"[PrefabMerge] 既存Prefabをマージ path={prefabAssetPath}, node={node.name}, type={node.type}, id={node.id}");
                 SyncComponentsAndChildren(existingPrefabContents, nodeGameObject, node);
                 return true;
             }

--- a/UnityFigmaBridge/Editor/Components/ComponentManager.cs
+++ b/UnityFigmaBridge/Editor/Components/ComponentManager.cs
@@ -534,7 +534,7 @@ namespace UnityFigmaBridge.Editor.Components
             foreach (var comp2 in sourceComponents)
             {
                 Type type = comp2.GetType();
-                Debug.Log($" 既存のものを落としてきたFigmaに入れる   add new component: {type.Name} to {target.name}");
+                Debug.Log($" 既存のものを落としてきたFigmaに入れる add new component: {type.Name} to {target.name}");
                 var component = target.AddComponent(type);
                 if (component == null)
                 {
@@ -588,7 +588,6 @@ namespace UnityFigmaBridge.Editor.Components
             var sourceNodeObject = source.GetComponent<FigmaNodeObject>();
             if (sourceNodeObject == null)
             {
-                Debug.Log("SyncNodeMetadata 既存にない");
                 return;
             }
 
@@ -601,39 +600,6 @@ namespace UnityFigmaBridge.Editor.Components
             targetNodeObject.Initialise(sourceNodeObject.NodeId, sourceNodeObject.NodeName);
         }
         
-         /// <summary>
-        /// 既存の子からNodeId/NodeNameベースの検索辞書を作る。
-        /// 名前の重複にも対応するため値は複数保持する。
-        /// </summary>
-        private static Dictionary<string, List<Transform>> BuildChildNodeMap(Transform parent)
-        {
-            var map = new Dictionary<string, List<Transform>>();
-            foreach (Transform child in parent)
-            {
-                var childNodeObject = child.GetComponent<FigmaNodeObject>();
-                if (childNodeObject == null)
-                {
-                    continue;
-                }
-
-                var key = GetNodeSearchKey(childNodeObject.NodeId, childNodeObject.NodeName);
-                if (string.IsNullOrEmpty(key))
-                {
-                    continue;
-                }
-
-                if (!map.TryGetValue(key, out var childList))
-                {
-                    childList = new List<Transform>();
-                    map[key] = childList;
-                }
-                Debug.Log($" ==== 既存の子からNodeId/NodeNameベースの検索辞書を作る Adding child {child.name} to map with key {key}");
-                childList.Add(child);
-            }
-
-            return map;
-        }
-
         /// <summary>
         /// NodeId を優先し、取得できない場合のみ NodeName を使う。
         /// id + name の複合キーだと名前変更で一致しなくなるので一旦ID優先で見る
@@ -654,69 +620,176 @@ namespace UnityFigmaBridge.Editor.Components
             return string.Empty;
         }
 
-         /// <summary>
-         /// 存在しない子があれば追加
-         /// 存在していればコンポーネントのコピーを実施する
-         /// </summary>
+        /// <summary>
+        /// 存在しない子があれば追加
+        /// 存在していればコンポーネントのコピーを実施する
+        /// 新規Figma に存在せず 既存オブジェクト にだけ存在する子は削除する
+        /// </summary>
         private static void MergeNodeRecursive(GameObject source, GameObject target, Node node)
         {
-            Debug.Log($" ==== 存在しない子があれば追加 Syncing children for source {source.name} and target {target.name} with node {node.name}");
-            // 対象かソースが無効なら
-            if(!target || !source)return;
-            
-            // コンポーネントノードの場合は追加しない
-            var componentNodeMarker = target.GetComponent<FigmaComponentNodeMarker>();
-            if (componentNodeMarker)
+            Debug.Log($"[Merge] {source.name} -> {target.name}");
+
+            if (!source || !target) return;
+            if (target.GetComponent<FigmaComponentNodeMarker>()) return;
+            if (node.children == null) return;
+
+            var sourceInfos = BuildSourceChildInfos(source, node);
+            var remainingTargets = GetChildren(target);
+
+            // ① IDで全件マッチ
+            MatchById(sourceInfos, remainingTargets);
+
+            // ② Nameで未マッチをマッチ
+            MatchByName(sourceInfos, remainingTargets);
+
+            // ③ 既存と同じを同期 or 新規追加
+            ApplyOrCreate(sourceInfos, target);
+
+            // ④ 余った既存オブジェクト削除
+            RemoveUnusedTargets(remainingTargets);
+        }
+        
+        private static List<SourceChildInfo> BuildSourceChildInfos(GameObject source, Node node)
+        {
+            var list = new List<SourceChildInfo>();
+
+            foreach (Transform child in source.transform)
             {
-                return;
+                var nodeObj = EnsureNodeObject(child);
+
+                var id = nodeObj.NodeId;
+                var name = string.IsNullOrEmpty(nodeObj.NodeName) ? child.name : nodeObj.NodeName;
+
+                var nodeChild = FindNodeChild(node, id, name);
+                if (nodeChild == null) continue;
+
+                list.Add(new SourceChildInfo
+                {
+                    Source = child,
+                    Node = nodeChild,
+                    Id = id,
+                    Name = name
+                });
             }
-            
-            var targetChildNodeMap = BuildChildNodeMap(target.transform);
-            foreach (Transform sourceChild in source.transform)
+
+            return list;
+        }
+        
+        private static void MatchById(List<SourceChildInfo> sources, List<Transform> targets)
+        {
+            foreach (var s in sources)
             {
-                var sourceChildNodeObject = sourceChild.GetComponent<FigmaNodeObject>();
-                var sourceNodeId = sourceChildNodeObject != null ? sourceChildNodeObject.NodeId : string.Empty;
-                var sourceNodeName = sourceChildNodeObject != null ? sourceChildNodeObject.NodeName : sourceChild.name;
-                var nodeSearchKey = GetNodeSearchKey(sourceNodeId, sourceNodeName);
+                if (string.IsNullOrEmpty(s.Id)) continue;
 
-                var nodeChildren = node.children;
-                var nodeChild = nodeChildren?.FirstOrDefault(n => n.id == sourceNodeId);
-                if (nodeChild == null)
-                {
-                    nodeChild = nodeChildren?.FirstOrDefault(n => n.name == sourceNodeName);
-                }
+                var match = targets.FirstOrDefault(t => GetNodeId(t) == s.Id);
+                if (match == null) continue;
 
-                // Nodeデータに存在しない場合は削除されたものとして無視する
-                if (nodeChild == null)
-                {
-                    continue;
-                }
+                s.Target = match;
+                targets.Remove(match);
 
-                Transform targetChild = null;
-                if (!string.IsNullOrEmpty(nodeSearchKey)
-                    && targetChildNodeMap.TryGetValue(nodeSearchKey, out var targetChildList)
-                    && targetChildList.Count > 0)
-                {
-                    targetChild = targetChildList[0];
-                    targetChildList.RemoveAt(0);
-                }
+                Debug.Log($"[Match-ID] {s.Name}");
+            }
+        }
+        
+        private static void MatchByName(List<SourceChildInfo> sources, List<Transform> targets)
+        {
+            foreach (var s in sources)
+            {
+                if (s.Target != null) continue;
+                if (string.IsNullOrEmpty(s.Name)) continue;
 
-                if (targetChild == null)
-                {
-                    Debug.Log($" ==== 子が存在しなければコピーして追加する。 {sourceChild.name} with NodeId {sourceNodeId} and NodeName {sourceNodeName} under parent {target.name}. Adding as new child.");
-                    // 子が存在しなければコピーして追加する。
-                    // 追加時も NodeId / NodeName を持つので次回の差分Syncで再利用できる。
-                    var copied = Object.Instantiate(sourceChild.gameObject, target.transform, false);
-                    copied.name = sourceChild.name;
-                    continue;
-                }
-                // すでに合致する子があれば再帰的にマージする。
-                // ここでNodeメタデータも同期して一致判定の精度を維持する。
-                Debug.Log($" ==== 子が存在すればコンポーネントをコピーしてプロパティを同期する。 {sourceChild.name} with NodeId {sourceNodeId} and NodeName {sourceNodeName} under parent {target.name}. Syncing properties and components.");
-                SyncComponentsAndChildren(sourceChild.gameObject, targetChild.gameObject, nodeChild);
+                var match = targets.FirstOrDefault(t => GetNodeName(t) == s.Name);
+                if (match == null) continue;
+
+                s.Target = match;
+                targets.Remove(match);
+
+                Debug.Log($"[Match-Name] {s.Name}");
             }
         }
 
+        private static void ApplyOrCreate(List<SourceChildInfo> sources, GameObject target)
+        {
+            foreach (var s in sources)
+            {
+                if (s.Target != null)
+                {
+                    Debug.Log($"[既存と同期] {s.Source.name}");
+                    SyncComponentsAndChildren(s.Source.gameObject, s.Target.gameObject, s.Node);
+                }
+                else
+                {
+                    var copy = Object.Instantiate(s.Source.gameObject, target.transform, false);
+                    copy.name = s.Source.name;
+
+                    Debug.Log($"[既存にないので作成 Create] {copy.name}");
+                }
+            }
+        }
+        
+        private static void RemoveUnusedTargets(List<Transform> targets)
+        {
+            foreach (var t in targets)
+            {
+                Debug.Log($"[余った既存を削除 Delete] {t.name}");
+                Object.DestroyImmediate(t.gameObject);
+            }
+        }
+        
+        private static List<Transform> GetChildren(GameObject obj)
+        {
+            var list = new List<Transform>();
+            foreach (Transform t in obj.transform) list.Add(t);
+            return list;
+        }
+
+        private static FigmaNodeObject EnsureNodeObject(Transform t)
+        {
+            var node = t.GetComponent<FigmaNodeObject>();
+            if (node != null) return node;
+
+            Debug.Log("既存にないのでFigmaNodeObject新規" + t.name);
+            node = t.gameObject.AddComponent<FigmaNodeObject>();
+            node.Initialise("", t.name);
+            return node;
+        }
+
+        private static Node FindNodeChild(Node parent, string id, string name)
+        {
+            if (!string.IsNullOrEmpty(id))
+            {
+                var byId = parent.children.FirstOrDefault(n => n.id == id);
+                if (byId != null) return byId;
+            }
+
+            if (!string.IsNullOrEmpty(name))
+            {
+                return parent.children.FirstOrDefault(n => n.name == name);
+            }
+
+            return null;
+        }
+
+        private static string GetNodeId(Transform t)
+        {
+            return t.GetComponent<FigmaNodeObject>()?.NodeId;
+        }
+
+        private static string GetNodeName(Transform t)
+        {
+            var node = t.GetComponent<FigmaNodeObject>();
+            return !string.IsNullOrEmpty(node?.NodeName) ? node.NodeName : t.name;
+        }
+        
+        private class SourceChildInfo
+        {
+            public Transform Source;
+            public Transform Target;
+            public Node Node;
+            public string Id;
+            public string Name;
+        }
+        
         /// <summary>
         /// コンポーネントコピー時に除外するタイプ (マーカー系のコンポーネントが主)
         /// </summary>
@@ -735,5 +808,6 @@ namespace UnityFigmaBridge.Editor.Components
             typeof(LayoutElement),
             typeof(LayoutGroup),
         };
+        
     }
 }

--- a/UnityFigmaBridge/Editor/Components/ComponentManager.cs
+++ b/UnityFigmaBridge/Editor/Components/ComponentManager.cs
@@ -91,10 +91,7 @@ namespace UnityFigmaBridge.Editor.Components
         {
             if (node == null || nodeGameObject == null) return false;
 
-            var assetType = GetAssetTypeForMergeTarget(node);
-            if (assetType == null) return false;
-
-            var cacheMap = FigmaAssetGuidMapManager.CreateMap(assetType.Value);
+            var cacheMap = FigmaAssetGuidMapManager.CreateMap(FigmaAssetGuidMapManager.AssetType.Component);
             var prefabAssetPath = cacheMap.GetAssetPath(node.id);
             if (string.IsNullOrEmpty(prefabAssetPath)) return false;
             if (!File.Exists(prefabAssetPath)) return false;
@@ -102,7 +99,7 @@ namespace UnityFigmaBridge.Editor.Components
             var existingPrefabContents = PrefabUtility.LoadPrefabContents(prefabAssetPath);
             try
             {
-                Debug.Log($"[PrefabMerge] 既存Prefabをマージ path={prefabAssetPath}, node={node.name}, type={node.type}, id={node.id}");
+                Debug.Log($"[PrefabMerge] merge existing prefab path={prefabAssetPath}, node={node.name}, type={node.type}, id={node.id}");
                 SyncComponentsAndChildren(existingPrefabContents, nodeGameObject, node);
                 return true;
             }
@@ -114,28 +111,6 @@ namespace UnityFigmaBridge.Editor.Components
             finally
             {
                 PrefabUtility.UnloadPrefabContents(existingPrefabContents);
-            }
-        }
-
-        /// <summary>
-        /// 指定ノードの既存Prefabを検索するためのAssetTypeを返す。
-        /// 対応する管理種別がないノードは null を返す。
-        /// </summary>
-        private static FigmaAssetGuidMapManager.AssetType? GetAssetTypeForMergeTarget(Node node)
-        {
-            if (node == null) return null;
-
-            switch (node.type)
-            {
-                case NodeType.COMPONENT:
-                case NodeType.COMPONENT_SET:
-                    return FigmaAssetGuidMapManager.AssetType.Component;
-                case NodeType.FRAME:
-                    return FigmaAssetGuidMapManager.AssetType.Screen;
-                case NodeType.CANVAS:
-                    return FigmaAssetGuidMapManager.AssetType.Page;
-                default:
-                    return null;
             }
         }
         

--- a/UnityFigmaBridge/Editor/Components/ComponentManager.cs
+++ b/UnityFigmaBridge/Editor/Components/ComponentManager.cs
@@ -75,6 +75,44 @@ namespace UnityFigmaBridge.Editor.Components
             // Unload
             PrefabUtility.UnloadPrefabContents(prefabContents);
         }
+
+        /// <summary>
+        /// 指定ノードに対応する既存Prefabが存在する場合、今回生成したGameObjectへ差分マージを行う。
+        /// ノード種別では判定せず、GUIDマップからPrefabパスを引けるかどうかで処理可否を決める。
+        /// 既存Prefabが見つからない場合は何もしない。
+        /// </summary>
+        /// <param name="node">対応するPrefabを検索するためのFigmaノード</param>
+        /// <param name="nodeGameObject">今回生成されたGameObject</param>
+        /// <returns>
+        /// 既存Prefabが見つかり、差分マージを実行した場合は true。
+        /// 対応するPrefabが存在しない、またはマージに失敗した場合は false。
+        /// </returns>
+        public static bool TryMergeWithExistingPrefab(Node node, GameObject nodeGameObject)
+        {
+            if (node == null || nodeGameObject == null) return false;
+
+            var cacheMap = FigmaAssetGuidMapManager.CreateMap(FigmaAssetGuidMapManager.AssetType.Component);
+            var prefabAssetPath = cacheMap.GetAssetPath(node.id);
+            if (string.IsNullOrEmpty(prefabAssetPath)) return false;
+            if (!File.Exists(prefabAssetPath)) return false;
+
+            var existingPrefabContents = PrefabUtility.LoadPrefabContents(prefabAssetPath);
+            try
+            {
+                Debug.Log($"[PrefabMerge] merge existing prefab path={prefabAssetPath}, node={node.name}, type={node.type}, id={node.id}");
+                SyncComponentsAndChildren(existingPrefabContents, nodeGameObject, node);
+                return true;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"既存Prefabとの差分マージに失敗: {prefabAssetPath}\n{e}");
+                return false;
+            }
+            finally
+            {
+                PrefabUtility.UnloadPrefabContents(existingPrefabContents);
+            }
+        }
         
         /// <summary>
         /// 生成済みのノードからコンポーネントPrefabを作成する

--- a/UnityFigmaBridge/Editor/Components/ComponentManager.cs
+++ b/UnityFigmaBridge/Editor/Components/ComponentManager.cs
@@ -496,12 +496,14 @@ namespace UnityFigmaBridge.Editor.Components
             foreach (var comp2 in sourceComponents)
             {
                 Type type = comp2.GetType();
+                Debug.Log($"  add new component: {type.Name} to {target.name}");
                 var component = target.AddComponent(type);
                 if (component == null)
                 {
                     if ((type == typeof(FigmaImage) || type == typeof(Image)) &&
                         target.GetComponent<Image>() is { } img)//nullチェック
                     {
+                        Debug.Log($"  reuse Image component and copy image values: {type.Name}");
                         img.CopyImage((Image)comp2, false);// SourceImageはFigmaが正なのでコピーしない
                         continue;
                     }
@@ -535,6 +537,7 @@ namespace UnityFigmaBridge.Editor.Components
                 img.sprite = sprite;
                 return;
             }
+            Debug.Log($"CopyComponent: {source.GetType().Name}　TargetComponent: {target.GetType().Name}");
             EditorUtility.CopySerialized(source,target);
         }
         

--- a/UnityFigmaBridge/Editor/Components/ComponentManager.cs
+++ b/UnityFigmaBridge/Editor/Components/ComponentManager.cs
@@ -59,14 +59,12 @@ namespace UnityFigmaBridge.Editor.Components
             var allComponentMarkers = prefabContents.GetComponentsInChildren<FigmaComponentNodeMarker>(true);
             foreach (var marker in allComponentMarkers)
             {
-                Debug.Log($"=====Removing 差分Syncに使う {marker.name} from prefab {sourcePrefab.name}");
                 Object.DestroyImmediate(marker);
             }
 
             var allSwapMarkers = prefabContents.GetComponentsInChildren<InstanceSwapMarker>(true);
             foreach (var swapMarker in allSwapMarkers)
             {
-                Debug.Log($"=====Removing 差分Syncに使う swap marker {swapMarker.name} from prefab {sourcePrefab.name}");
                 Object.DestroyImmediate(swapMarker);
             }
 
@@ -76,17 +74,13 @@ namespace UnityFigmaBridge.Editor.Components
             PrefabUtility.UnloadPrefabContents(prefabContents);
         }
 
-        /// <summary>
-        /// 指定ノードに対応する既存Prefabが存在する場合、今回生成したGameObjectへ差分マージを行う。
-        /// ノード種別では判定せず、GUIDマップからPrefabパスを引けるかどうかで処理可否を決める。
-        /// 既存Prefabが見つからない場合は何もしない。
-        /// </summary>
-        /// <param name="node">対応するPrefabを検索するためのFigmaノード</param>
-        /// <param name="nodeGameObject">今回生成されたGameObject</param>
         /// <returns>
         /// 既存Prefabが見つかり、差分マージを実行した場合は true。
         /// 対応するPrefabが存在しない、またはマージに失敗した場合は false。
         /// </returns>
+        /// <param name="node">対応するPrefabを検索するためのFigmaノード</param>
+        /// <param name="nodeGameObject">今回生成されたGameObject</param>
+        /// <param name="path">既存オブジェクト読み込み先のパス</param>
         public static bool TryMergeWithExistingPrefab(Node node, GameObject nodeGameObject,string path)
         {
             if (node == null || nodeGameObject == null) return false;
@@ -272,7 +266,6 @@ namespace UnityFigmaBridge.Editor.Components
                 var figmaNodeComponent = addedReplacementComponent.GetComponent<FigmaNodeObject>();
                 if (figmaNodeComponent == null)
                 {
-                    Debug.Log("FigmaNodeObject存在してないので追加");
                     figmaNodeComponent = addedReplacementComponent.AddComponent<FigmaNodeObject>();
                 }
                 figmaNodeComponent.Initialise(placeholder.NodeId, placeholder.name);
@@ -606,7 +599,6 @@ namespace UnityFigmaBridge.Editor.Components
                 return;
             }
 
-            Debug.Log($"CopyComponent: {source.GetType().Name} TargetComponent: {target.GetType().Name}");
             //sourceをTargetにコピー
             EditorUtility.CopySerialized(source, target);
             // コピー後、source 側 subtree 内を指している参照を target 側 subtree の対応オブジェクトへ張り替える
@@ -736,11 +728,6 @@ namespace UnityFigmaBridge.Editor.Components
         {
             var sourceNodeObject = EnsureNodeObject(source.transform);
             var targetNodeObject = EnsureNodeObject(target.transform);
-
-            Debug.Log(
-                $"[NodeMetadata] copy target({target.name}) -> source({source.name}) " +
-                $"NodeId={targetNodeObject.NodeId}, NodeName={targetNodeObject.NodeName}");
-
             sourceNodeObject.Initialise(targetNodeObject.NodeId, targetNodeObject.NodeName);
         }
 
@@ -797,19 +784,6 @@ namespace UnityFigmaBridge.Editor.Components
         private static List<SourceChildInfo> BuildSourceChildInfos(GameObject source,  Node node)
         {
             var list = new List<SourceChildInfo>();            
-            // 自身を登録
-            // var selfNodeObj = EnsureNodeObject(source.transform);
-            // var selfId = selfNodeObj.NodeId;
-            // var selfName = string.IsNullOrEmpty(selfNodeObj.NodeName) ? source.name : selfNodeObj.NodeName;
-            
-            // list.Add(new SourceChildInfo
-            //  {
-            //      Source = source.transform,
-            //      Node = node,
-            //      Id = selfId,
-            //      Name = selfName
-            // });
-
             //子を登録
             foreach (Transform child in source.transform)
             {
@@ -901,10 +875,9 @@ namespace UnityFigmaBridge.Editor.Components
         
         private static List<Transform> GetChildren(GameObject obj)
         {
-            var list = new List<Transform>();
-            foreach (Transform t in obj.transform)
-                list.Add(t);
-            return list;
+            return obj.GetComponentsInChildren<Transform>()
+              .Where(t => t != obj.transform)
+              .ToList();
         }
 
         private static FigmaNodeObject EnsureNodeObject(Transform t)

--- a/UnityFigmaBridge/Editor/Components/ComponentManager.cs
+++ b/UnityFigmaBridge/Editor/Components/ComponentManager.cs
@@ -17,6 +17,7 @@ using UnityFigmaBridge.Editor.Utils;
 using UnityFigmaBridge.Runtime.UI;
 using Component = UnityEngine.Component;
 using Object = UnityEngine.Object;
+using Debug = UnityEngine.Debug;
 
 namespace UnityFigmaBridge.Editor.Components
 {

--- a/UnityFigmaBridge/Editor/Components/ComponentManager.cs
+++ b/UnityFigmaBridge/Editor/Components/ComponentManager.cs
@@ -51,9 +51,21 @@ namespace UnityFigmaBridge.Editor.Components
         {
             var assetPath = AssetDatabase.GetAssetPath(sourcePrefab);
             var prefabContents = PrefabUtility.LoadPrefabContents(assetPath);
-            var allPlaceholderComponents = prefabContents.GetComponentsInChildren<FigmaNodeObject>();
-            foreach (var placeholder in allPlaceholderComponents)
-                Object.DestroyImmediate(placeholder);
+
+            // 差分Syncに使う FigmaNodeObject は残し、プレースホルダーマーカーだけ削除する。
+            // 再生成ではなく差分反映するため、NodeId と NodeName は維持する。
+            var allComponentMarkers = prefabContents.GetComponentsInChildren<FigmaComponentNodeMarker>(true);
+            foreach (var marker in allComponentMarkers)
+            {
+                Object.DestroyImmediate(marker);
+            }
+
+            var allSwapMarkers = prefabContents.GetComponentsInChildren<InstanceSwapMarker>(true);
+            foreach (var swapMarker in allSwapMarkers)
+            {
+                Object.DestroyImmediate(swapMarker);
+            }
+
             // Save
             PrefabUtility.SaveAsPrefabAsset(prefabContents, assetPath);
             // Unload
@@ -216,7 +228,7 @@ namespace UnityFigmaBridge.Editor.Components
                 }
                 else
                 {
-                    figmaNodeComponent.NodeId = placeholder.NodeId;
+                    figmaNodeComponent.Initialise(placeholder.NodeId, placeholder.name);
                 }
                 
                 // Copy transform order
@@ -433,6 +445,9 @@ namespace UnityFigmaBridge.Editor.Components
         /// </summary>
         public static void SyncComponentsAndChildren(GameObject source, GameObject target, Node node)
         {
+            // Figma のノード情報を最新に保つ。
+            // 差分Syncの一致判定に使うため、最初にメタデータを更新する。
+            SyncNodeMetadata(source, target);
             SyncComponents(source, target);
             SyncChildren(source, target, node);
         }
@@ -507,6 +522,79 @@ namespace UnityFigmaBridge.Editor.Components
             EditorUtility.CopySerialized(source,target);
         }
         
+        /// <summary>
+        /// Figmaノードのメタデータを target に反映する。
+        /// NodeId / NodeName を更新して次回Sync時の一致精度を上げる。
+        /// </summary>
+        private static void SyncNodeMetadata(GameObject source, GameObject target)
+        {
+            var sourceNodeObject = source.GetComponent<FigmaNodeObject>();
+            if (sourceNodeObject == null)
+            {
+                return;
+            }
+
+            var targetNodeObject = target.GetComponent<FigmaNodeObject>();
+            if (targetNodeObject == null)
+            {
+                targetNodeObject = target.AddComponent<FigmaNodeObject>();
+            }
+
+            targetNodeObject.Initialise(sourceNodeObject.NodeId, sourceNodeObject.NodeName);
+        }
+        
+         /// <summary>
+        /// 既存の子からNodeId/NodeNameベースの検索辞書を作る。
+        /// 名前の重複にも対応するため値は複数保持する。
+        /// </summary>
+        private static Dictionary<string, List<Transform>> BuildChildNodeMap(Transform parent)
+        {
+            var map = new Dictionary<string, List<Transform>>();
+            foreach (Transform child in parent)
+            {
+                var childNodeObject = child.GetComponent<FigmaNodeObject>();
+                if (childNodeObject == null)
+                {
+                    continue;
+                }
+
+                var key = GetNodeSearchKey(childNodeObject.NodeId, childNodeObject.NodeName);
+                if (string.IsNullOrEmpty(key))
+                {
+                    continue;
+                }
+
+                if (!map.TryGetValue(key, out var childList))
+                {
+                    childList = new List<Transform>();
+                    map[key] = childList;
+                }
+
+                childList.Add(child);
+            }
+
+            return map;
+        }
+
+        /// <summary>
+        /// NodeId を優先し、取得できない場合のみ NodeName を使う。
+        /// 前方一致の誤判定を避けるため prefix を固定する。
+        /// </summary>
+        private static string GetNodeSearchKey(string nodeId, string nodeName)
+        {
+            if (!string.IsNullOrEmpty(nodeId))
+            {
+                return $"id:{nodeId}";
+            }
+
+            if (!string.IsNullOrEmpty(nodeName))
+            {
+                return $"name:{nodeName}";
+            }
+
+            return string.Empty;
+        }
+
          /// <summary>
          /// 存在しない子があれば追加
          /// 存在していればコンポーネントのコピーを実施する
@@ -523,30 +611,47 @@ namespace UnityFigmaBridge.Editor.Components
                 return;
             }
             
+            var targetChildNodeMap = BuildChildNodeMap(target.transform);
             foreach (Transform sourceChild in source.transform)
             {
-                var targetChild = target.transform.Find(sourceChild.name);
+                var sourceChildNodeObject = sourceChild.GetComponent<FigmaNodeObject>();
+                var sourceNodeId = sourceChildNodeObject != null ? sourceChildNodeObject.NodeId : string.Empty;
+                var sourceNodeName = sourceChildNodeObject != null ? sourceChildNodeObject.NodeName : sourceChild.name;
+                var nodeSearchKey = GetNodeSearchKey(sourceNodeId, sourceNodeName);
+
                 var nodeChildren = node.children;
-                var nodeChild = nodeChildren?.FirstOrDefault(n => n.name == sourceChild.name);
+                var nodeChild = nodeChildren?.FirstOrDefault(n => n.id == sourceNodeId);
+                if (nodeChild == null)
+                {
+                    nodeChild = nodeChildren?.FirstOrDefault(n => n.name == sourceNodeName);
+                }
 
                 // Nodeデータに存在しない場合は削除されたものとして無視する
                 if (nodeChild == null)
                 {
                     continue;
                 }
+
+                Transform targetChild = null;
+                if (!string.IsNullOrEmpty(nodeSearchKey)
+                    && targetChildNodeMap.TryGetValue(nodeSearchKey, out var targetChildList)
+                    && targetChildList.Count > 0)
+                {
+                    targetChild = targetChildList[0];
+                    targetChildList.RemoveAt(0);
+                }
+
                 if (targetChild == null)
                 {
-                    // 基本ここには来ないはず
-                    // 子が存在しなければコピーして追加
+                    // 子が存在しなければコピーして追加する。
+                    // 追加時も NodeId / NodeName を持つので次回の差分Syncで再利用できる。
                     var copied = Object.Instantiate(sourceChild.gameObject, target.transform, false);
                     copied.name = sourceChild.name;
+                    continue;
                 }
-                else
-                {
-                    // すでに同名の子があれば再帰的にマージ
-                    SyncComponents(sourceChild.gameObject, targetChild.gameObject);
-                    SyncChildren(sourceChild.gameObject, targetChild.gameObject, nodeChild);
-                }
+                // すでに合致する子があれば再帰的にマージする。
+                // ここでNodeメタデータも同期して一致判定の精度を維持する。
+                SyncComponentsAndChildren(sourceChild.gameObject, targetChild.gameObject, nodeChild);
             }
         }
 

--- a/UnityFigmaBridge/Editor/Components/ComponentManager.cs
+++ b/UnityFigmaBridge/Editor/Components/ComponentManager.cs
@@ -91,10 +91,51 @@ namespace UnityFigmaBridge.Editor.Components
         {
             if (node == null || nodeGameObject == null) return false;
 
-            var cacheMap = FigmaAssetGuidMapManager.CreateMap(FigmaAssetGuidMapManager.AssetType.Component);;
+            var cacheMap = FigmaAssetGuidMapManager.CreateMap(FigmaAssetGuidMapManager.AssetType.Component);
             var prefabAssetPath = cacheMap.GetAssetPath(node.id);
+
+            return TryMergeFromPrefabPath(prefabAssetPath, node, nodeGameObject);
+        }
+        
+        /// <summary>
+        /// 生成済みのノードからコンポーネントPrefabを作成する
+        /// </summary>
+        /// <param name="node">元となるFigmaノード</param>
+        /// <param name="parentNode">親ノード</param>
+        /// <param name="nodeGameObject">生成されたGameObject</param>
+        /// <param name="figmaImportProcessData">インポート処理で使用するデータ</param>
+        public static void GenerateComponentAssetFromNode(Node node, Node parentNode, GameObject nodeGameObject, FigmaImportProcessData figmaImportProcessData)
+        {
+            if (ImportSessionCache.remoteComponentFlagMap.Contains(node.id)) return;
+
+            var nodeName = parentNode is { type: NodeType.COMPONENT_SET }
+                ? $"{parentNode.name}-{node.name}"
+                : node.name;
+
+            var componentCount = figmaImportProcessData.ComponentData.GetComponentNameCount(nodeName);
+            figmaImportProcessData.ComponentData.IncrementComponentNameCount(nodeName, 1);
+
+            var cacheMap = FigmaAssetGuidMapManager.CreateMap(FigmaAssetGuidMapManager.AssetType.Component);
+            var prefabAssetPath = cacheMap.GetAssetPath(node.id);
+            if (string.IsNullOrEmpty(prefabAssetPath))
+            {
+                prefabAssetPath = FigmaPaths.GetPathForComponentPrefab(nodeName, componentCount);
+            }
+
+            TryMergeFromPrefabPath(prefabAssetPath, node, nodeGameObject);
+
+            var componentPrefab = PrefabUtility.SaveAsPrefabAssetAndConnect(nodeGameObject, prefabAssetPath, InteractionMode.UserAction);
+            figmaImportProcessData.ComponentData.RegisterComponentPrefab(node.id, componentPrefab);
+
+            var guid = AssetDatabase.AssetPathToGUID(prefabAssetPath);
+            cacheMap.Add(node.id, guid, nodeName);
+        }
+        
+        private static bool TryMergeFromPrefabPath(string prefabAssetPath, Node node, GameObject nodeGameObject)
+        {
             if (string.IsNullOrEmpty(prefabAssetPath)) return false;
             if (!File.Exists(prefabAssetPath)) return false;
+            if (node == null || nodeGameObject == null) return false;
 
             var existingPrefabContents = PrefabUtility.LoadPrefabContents(prefabAssetPath);
             try
@@ -112,58 +153,6 @@ namespace UnityFigmaBridge.Editor.Components
             {
                 PrefabUtility.UnloadPrefabContents(existingPrefabContents);
             }
-        }
-        
-        /// <summary>
-        /// 生成済みのノードからコンポーネントPrefabを作成する
-        /// </summary>
-        /// <param name="node">元となるFigmaノード</param>
-        /// <param name="parentNode">親ノード</param>
-        /// <param name="nodeGameObject">生成されたGameObject</param>
-        /// <param name="figmaImportProcessData">インポート処理で使用するデータ</param>
-        public static void GenerateComponentAssetFromNode(Node node, Node parentNode, GameObject nodeGameObject, FigmaImportProcessData figmaImportProcessData)
-        {
-            // 外部コンポーネントだった場合は無視
-            if(ImportSessionCache.remoteComponentFlagMap.Contains(node.id)) return;
-            
-            // If this is part of a component set (eg a variant), append the name of the component set to the component name
-            var nodeName=parentNode is { type: NodeType.COMPONENT_SET } ? $"{parentNode.name}-{node.name}" : node.name;
-            var componentCount = figmaImportProcessData.ComponentData.GetComponentNameCount(nodeName);
-            figmaImportProcessData.ComponentData.IncrementComponentNameCount(nodeName,1);
-
-            // ここですでにキャッシュされたファイルが存在する場合はその場所に生成する
-            var cacheMap = FigmaAssetGuidMapManager.CreateMap(FigmaAssetGuidMapManager.AssetType.Component);
-            var prefabAssetPath = cacheMap.GetAssetPath(node.id);
-            if (string.IsNullOrEmpty(prefabAssetPath))
-            {
-                prefabAssetPath = FigmaPaths.GetPathForComponentPrefab(nodeName,componentCount);
-            }
-        
-            // 既存Prefabがある場合は、Unity側変更を今回生成物へ差分マージする
-            if (File.Exists(prefabAssetPath))
-            {
-                var existingPrefabContents = PrefabUtility.LoadPrefabContents(prefabAssetPath);
-                try
-                {
-                    Debug.Log($"==== 既存Prefabとの差分マージ開始: {prefabAssetPath}");
-
-                    SyncComponentsAndChildren(existingPrefabContents, nodeGameObject, node);
-                }
-                catch (Exception e)
-                {
-                    Debug.LogWarning($"既存Prefabとの差分マージに失敗: {prefabAssetPath}\n{e}");
-                }
-                finally
-                {
-                    PrefabUtility.UnloadPrefabContents(existingPrefabContents);
-                }
-            }
-
-            
-            var componentPrefab = PrefabUtility.SaveAsPrefabAssetAndConnect(nodeGameObject, prefabAssetPath, InteractionMode.UserAction);
-            figmaImportProcessData.ComponentData.RegisterComponentPrefab(node.id,componentPrefab);
-            var guid = AssetDatabase.AssetPathToGUID(prefabAssetPath);
-            cacheMap.Add(node.id, guid, nodeName);
         }
         
         /// <summary>

--- a/UnityFigmaBridge/Editor/Components/ComponentManager.cs
+++ b/UnityFigmaBridge/Editor/Components/ComponentManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using TMPro;
@@ -57,12 +58,14 @@ namespace UnityFigmaBridge.Editor.Components
             var allComponentMarkers = prefabContents.GetComponentsInChildren<FigmaComponentNodeMarker>(true);
             foreach (var marker in allComponentMarkers)
             {
+                Debug.Log($"=====Removing 差分Syncに使う {marker.name} from prefab {sourcePrefab.name}");
                 Object.DestroyImmediate(marker);
             }
 
             var allSwapMarkers = prefabContents.GetComponentsInChildren<InstanceSwapMarker>(true);
             foreach (var swapMarker in allSwapMarkers)
             {
+                Debug.Log($"=====Removing 差分Syncに使う swap marker {swapMarker.name} from prefab {sourcePrefab.name}");
                 Object.DestroyImmediate(swapMarker);
             }
 
@@ -569,7 +572,7 @@ namespace UnityFigmaBridge.Editor.Components
                     childList = new List<Transform>();
                     map[key] = childList;
                 }
-
+                Debug.Log($" ==== 既存の子からNodeId/NodeNameベースの検索辞書を作る Adding child {child.name} to map with key {key}");
                 childList.Add(child);
             }
 
@@ -601,6 +604,7 @@ namespace UnityFigmaBridge.Editor.Components
          /// </summary>
         private static void SyncChildren(GameObject source, GameObject target, Node node)
         {
+            Debug.Log($" ==== 存在しない子があれば追加 Syncing children for source {source.name} and target {target.name} with node {node.name}");
             // 対象かソースが無効なら
             if(!target || !source)return;
             
@@ -643,6 +647,7 @@ namespace UnityFigmaBridge.Editor.Components
 
                 if (targetChild == null)
                 {
+                    Debug.Log($" ==== 子が存在しなければコピーして追加する。 {sourceChild.name} with NodeId {sourceNodeId} and NodeName {sourceNodeName} under parent {target.name}. Adding as new child.");
                     // 子が存在しなければコピーして追加する。
                     // 追加時も NodeId / NodeName を持つので次回の差分Syncで再利用できる。
                     var copied = Object.Instantiate(sourceChild.gameObject, target.transform, false);
@@ -651,6 +656,7 @@ namespace UnityFigmaBridge.Editor.Components
                 }
                 // すでに合致する子があれば再帰的にマージする。
                 // ここでNodeメタデータも同期して一致判定の精度を維持する。
+                Debug.Log($" ==== 子が存在すればコンポーネントをコピーしてプロパティを同期する。 {sourceChild.name} with NodeId {sourceNodeId} and NodeName {sourceNodeName} under parent {target.name}. Syncing properties and components.");
                 SyncComponentsAndChildren(sourceChild.gameObject, targetChild.gameObject, nodeChild);
             }
         }

--- a/UnityFigmaBridge/Editor/Extension/ImportCache/FigmaAssetGuidMapData.cs
+++ b/UnityFigmaBridge/Editor/Extension/ImportCache/FigmaAssetGuidMapData.cs
@@ -82,12 +82,14 @@ namespace UnityFigmaBridge.Editor.Extension.ImportCache
             {
                 _assetMap.Add(nodeId, (guid, assetName));
                 EditorUtility.SetDirty(this);
+                return;
             }
             
             if (!guid.Equals(entryValue.guid) || !assetName.Equals(entryValue.assetName))
             {
-                entryValue.guid = guid;
-                entryValue.assetName = assetName;
+                // 既存キー更新時はローカル変数更新だけでは辞書に反映されない。
+                // 明示的に再代入して、GUID/名前の変更を保存する。
+                _assetMap[nodeId] = (guid, assetName);
                 EditorUtility.SetDirty(this);
             }
         }

--- a/UnityFigmaBridge/Editor/Extension/ImportCache/FigmaAssetGuidMapManager.cs
+++ b/UnityFigmaBridge/Editor/Extension/ImportCache/FigmaAssetGuidMapManager.cs
@@ -3,6 +3,7 @@ using System.IO;
 using UnityEditor;
 using UnityEngine;
 using UnityFigmaBridge.Editor.Utils;
+using UnityFigmaBridge.Editor.FigmaApi;
 
 namespace UnityFigmaBridge.Editor.Extension.ImportCache
 {
@@ -51,6 +52,12 @@ namespace UnityFigmaBridge.Editor.Extension.ImportCache
             return map;
         }
 
+        public static FigmaAssetGuidMapData CreateMap(NodeType nodeType)
+        {
+            return CreateMap(ConvertNodeTypeToAssetType(nodeType));
+        }
+
+
         public static FigmaAssetGuidMapData GetMap(AssetType assetType)
         {
             return _mapContenar.GetValueOrDefault(assetType);
@@ -72,7 +79,24 @@ namespace UnityFigmaBridge.Editor.Extension.ImportCache
             _mapContenar.Clear();
         }
 
+        private static AssetType ConvertNodeTypeToAssetType(NodeType nodeType)
+        {
+            switch (nodeType)
+            {
+                case NodeType.COMPONENT:
+                case NodeType.COMPONENT_SET:
+                case NodeType.INSTANCE:
+                case NodeType.FRAME:
+                    return AssetType.Component;
 
+                default:
+                    throw new System.ArgumentOutOfRangeException(
+                        nameof(nodeType),
+                        nodeType,
+                        $"NodeType {nodeType} に対応する AssetType が定義されていません。");
+            }
+        }
+        
         private static string MakePath(AssetType assetType)
         {
             return FigmaPaths.FigmaFileRootFolder + ComponentCacheDataDir + assetType.ToString() + ".asset";

--- a/UnityFigmaBridge/Editor/Extension/ImportCache/FigmaAssetGuidMapManager.cs
+++ b/UnityFigmaBridge/Editor/Extension/ImportCache/FigmaAssetGuidMapManager.cs
@@ -85,7 +85,6 @@ namespace UnityFigmaBridge.Editor.Extension.ImportCache
             {
                 case NodeType.COMPONENT:
                 case NodeType.COMPONENT_SET:
-                case NodeType.INSTANCE:
                 case NodeType.FRAME:
                     return AssetType.Component;
 

--- a/UnityFigmaBridge/Editor/Nodes/FigmaAssetGenerator.cs
+++ b/UnityFigmaBridge/Editor/Nodes/FigmaAssetGenerator.cs
@@ -316,6 +316,34 @@ namespace UnityFigmaBridge.Editor.Nodes
         }
 
         /// <summary>
+        /// コンポーネントPrefabを生成・更新するべきノードかどうかを判定する。
+        /// 既存Prefabとのマージ対象判定とは分けて管理し、ここでは
+        /// 「新規保存や更新対象として扱うノード」を絞り込む。
+        /// </summary>
+        /// <param name="node">判定対象のFigmaノード</param>
+        /// <param name="parentNode">親Figmaノード</param>
+        /// <param name="figmaImportProcessData">インポート処理データ</param>
+        /// <returns>
+        /// コンポーネントPrefabを生成・更新する対象であれば true。
+        /// それ以外は false。
+        /// </returns>
+        private static bool ShouldGenerateComponentAsset(Node node, Node parentNode, FigmaImportProcessData figmaImportProcessData)
+        {
+            if (node == null) return false;
+
+            // 外部コンポーネントはローカルPrefabを生成しない
+            if (ImportSessionCache.remoteComponentFlagMap.Contains(node.id))
+                return false;
+
+            // substitution はPrefab生成対象外
+            if (FigmaNodeManager.NodeIsSubstitution(node, figmaImportProcessData))
+                return false;
+
+            // 基本は component 定義のみPrefab化する
+            return node.type == NodeType.COMPONENT;
+        }
+
+        /// <summary>
         /// 既存Prefabとのマージを試みるべきノードかどうかを判定する。
         /// ここではノード種別では絞り込まず、既存アセットが存在する可能性があるノードを広く対象にする。
         /// 実際にマージされるかどうかは TryMergeWithExistingPrefab 内で

--- a/UnityFigmaBridge/Editor/Nodes/FigmaAssetGenerator.cs
+++ b/UnityFigmaBridge/Editor/Nodes/FigmaAssetGenerator.cs
@@ -396,6 +396,13 @@ namespace UnityFigmaBridge.Editor.Nodes
             // Restore original position
             screenRectTransform.anchoredPosition = current;
 
+            // FRAME ノードも次回差分マージ対象にできるよう、node.id とPrefab GUIDを対応付ける。
+            // Component マップを流用し、TryMergeWithExistingPrefab から逆引きできる状態を維持する。
+            var componentMap = FigmaAssetGuidMapManager.CreateMap(FigmaAssetGuidMapManager.AssetType.Component);
+            var screenPrefabPath = AssetDatabase.GetAssetPath(screenPrefab);
+            var screenPrefabGuid = AssetDatabase.AssetPathToGUID(screenPrefabPath);
+            componentMap.Add(node.id, screenPrefabGuid, screenPrefab.name);
+
             // If we are building the prototype flow, add this to the current flowScreen controller
             if (figmaImportProcessData.Settings.BuildPrototypeFlow)
             {

--- a/UnityFigmaBridge/Editor/Nodes/FigmaAssetGenerator.cs
+++ b/UnityFigmaBridge/Editor/Nodes/FigmaAssetGenerator.cs
@@ -13,6 +13,7 @@ using UnityFigmaBridge.Editor.PrototypeFlow;
 using UnityFigmaBridge.Editor.Utils;
 using UnityFigmaBridge.Runtime.UI;
 using Object = UnityEngine.Object;
+using Debug = UnityEngine.Debug;
 
 namespace UnityFigmaBridge.Editor.Nodes
 {

--- a/UnityFigmaBridge/Editor/Nodes/FigmaAssetGenerator.cs
+++ b/UnityFigmaBridge/Editor/Nodes/FigmaAssetGenerator.cs
@@ -146,8 +146,9 @@ namespace UnityFigmaBridge.Editor.Nodes
                 NodeTransformManager.ApplyFigmaTransform(nodeRectTransform, figmaNode, parentFigmaNode,nodeRecursionDepth >0);
             }
             
-            // Add on a figmaNode to store the reference to the FIGMA figmaNode id
-            nodeGameObject.AddComponent<FigmaNodeObject>().NodeId=figmaNode.id;
+            // NodeId と NodeName を主キーにして再Sync時のマージ対象を見つける。
+            var figmaNodeObject = nodeGameObject.AddComponent<FigmaNodeObject>();
+            figmaNodeObject.Initialise(figmaNode.id, figmaNode.name);
 
             // If this is a Figma mask object we'll add a mask component (but dont render) 
             if (figmaNode.isMask)

--- a/UnityFigmaBridge/Editor/Nodes/FigmaAssetGenerator.cs
+++ b/UnityFigmaBridge/Editor/Nodes/FigmaAssetGenerator.cs
@@ -63,9 +63,6 @@ namespace UnityFigmaBridge.Editor.Nodes
             
             // Instantiate all components
             ComponentManager.InstantiateAllComponentPrefabs(figmaImportProcessData);
-
-            // Remove all temporary components that were created along the way
-            ComponentManager.RemoveAllTemporaryNodeComponents(figmaImportProcessData);
             
             // At the very end, we want to apply figmaNode behaviour where required
             BehaviourBindingManager.BindBehaviours(figmaImportProcessData);

--- a/UnityFigmaBridge/Editor/Nodes/FigmaAssetGenerator.cs
+++ b/UnityFigmaBridge/Editor/Nodes/FigmaAssetGenerator.cs
@@ -270,6 +270,13 @@ namespace UnityFigmaBridge.Editor.Nodes
                 }
             }
             
+            Debug.Log(
+                $"[BuildFigmaNode2] enter ");
+            if (figmaNode.name == "CharaDetailTop")
+            {
+                Debug.Log("test");
+            }
+            
             // スクロールコンテンツ生成の最終処理
             // レイアウト未使用の場合は、生成された子全体が収まるようにサイズを再計算する
             if (scrollContentGameObject != null && figmaNode.layoutMode == Node.LayoutMode.NONE)

--- a/UnityFigmaBridge/Editor/Nodes/FigmaAssetGenerator.cs
+++ b/UnityFigmaBridge/Editor/Nodes/FigmaAssetGenerator.cs
@@ -218,10 +218,10 @@ namespace UnityFigmaBridge.Editor.Nodes
                 // If this node is visible, mark the game object is inactive
                 if (!figmaNode.visible) nodeGameObject.SetActive(false);
 
-                if (ShouldTryMergeExistingPrefab(figmaNode))
-                {
-                    ComponentManager.TryMergeWithExistingPrefab(figmaNode, nodeGameObject);
-                }
+               // if (ShouldTryMergeExistingPrefab(figmaNode))
+               // {
+                   // ComponentManager.TryMergeWithExistingPrefab(figmaNode, nodeGameObject);
+               // }
 
                 if (ShouldGenerateComponentAsset(figmaNode, parentFigmaNode, figmaImportProcessData))
                 {
@@ -308,10 +308,10 @@ namespace UnityFigmaBridge.Editor.Nodes
             // If this node is visible, mark the game object is inactive
             if (!figmaNode.visible) nodeGameObject.SetActive(false);
             
-            if (ShouldTryMergeExistingPrefab(figmaNode))
-            {
-                ComponentManager.TryMergeWithExistingPrefab(figmaNode, nodeGameObject);
-            }
+            // if (ShouldTryMergeExistingPrefab(figmaNode))
+            // {
+            //     ComponentManager.TryMergeWithExistingPrefab(figmaNode, nodeGameObject);
+            // }
 
             if (ShouldGenerateComponentAsset(figmaNode, parentFigmaNode, figmaImportProcessData))
             {
@@ -383,27 +383,29 @@ namespace UnityFigmaBridge.Editor.Nodes
         {
             var screenNameCount = figmaImportProcessData.ScreenPrefabNameCounter.TryGetValue(node.name, out var value)
                 ? value : 0;
-            
-            // Increment count to ensure no naming collisions
+
             figmaImportProcessData.ScreenPrefabNameCounter[node.name] = screenNameCount + 1;
-            
-            // We want prefab to be stored with a default position, so reset and restore
+
             var current = screenRectTransform.anchoredPosition;
             screenRectTransform.anchoredPosition = Vector2.zero;
-            // Write prefab
-            var screenPrefab = PrefabUtility.SaveAsPrefabAssetAndConnect(screenRectTransform.gameObject,
-                    FigmaPaths.GetPathForScreenPrefab(node,screenNameCount), InteractionMode.UserAction);
-            // Restore original position
+
+            var screenPrefabPath = FigmaPaths.GetPathForScreenPrefab(node, screenNameCount);
+
+            // save前に既存Prefabとマージ
+            ComponentManager.TryMergeWithExistingPrefab(node, screenRectTransform.gameObject, screenPrefabPath);
+
+            var screenPrefab = PrefabUtility.SaveAsPrefabAssetAndConnect(
+                screenRectTransform.gameObject,
+                screenPrefabPath,
+                InteractionMode.UserAction);
+
             screenRectTransform.anchoredPosition = current;
 
-            // FRAME ノードも次回差分マージ対象にできるよう、node.id とPrefab GUIDを対応付ける。
-            // Component マップを流用し、TryMergeWithExistingPrefab から逆引きできる状態を維持する。
+            // save後にGUID map登録
             var componentMap = FigmaAssetGuidMapManager.CreateMap(FigmaAssetGuidMapManager.AssetType.Component);
-            var screenPrefabPath = AssetDatabase.GetAssetPath(screenPrefab);
             var screenPrefabGuid = AssetDatabase.AssetPathToGUID(screenPrefabPath);
             componentMap.Add(node.id, screenPrefabGuid, screenPrefab.name);
 
-            // If we are building the prototype flow, add this to the current flowScreen controller
             if (figmaImportProcessData.Settings.BuildPrototypeFlow)
             {
                 figmaImportProcessData.PrototypeFlowController.RegisterFigmaScreen(new FigmaFlowScreen
@@ -411,11 +413,10 @@ namespace UnityFigmaBridge.Editor.Nodes
                     FigmaScreenPrefab = screenPrefab,
                     FigmaNodeId = node.id,
                     FigmaScreenName = FigmaPaths.GetFileNameForNode(node, screenNameCount),
-                    // Store the section that this is part of (if applicable)
                     ParentSectionNodeId = parentNode is { type: NodeType.SECTION } ? parentNode.id : string.Empty
                 });
             }
-            
+
             figmaImportProcessData.ScreenPrefabs.Add(screenPrefab);
         }
         
@@ -433,6 +434,7 @@ namespace UnityFigmaBridge.Editor.Nodes
             
             // Increment count to ensure no naming collisions
             figmaImportProcessData.PagePrefabNameCounter[node.name] = pageNameCount + 1;
+            Debug.Log("SaveAsPrefabAssetAndConnect2 : "+pageGameObject.gameObject.name);
 
             var pagePrefab = PrefabUtility.SaveAsPrefabAssetAndConnect(pageGameObject,
                 FigmaPaths.GetPathForPagePrefab(node,pageNameCount),InteractionMode.UserAction);

--- a/UnityFigmaBridge/Editor/Nodes/FigmaAssetGenerator.cs
+++ b/UnityFigmaBridge/Editor/Nodes/FigmaAssetGenerator.cs
@@ -129,6 +129,13 @@ namespace UnityFigmaBridge.Editor.Nodes
             // ダミーオブジェクトは生成しない
             if (figmaNode.IsDummyNode()) return null;
             
+            Debug.Log(
+                $"[BuildFigmaNode] enter " +
+                $"name:{figmaNode.name}, id:{figmaNode.id}, type:{figmaNode.type}, " +
+                $"parent:{parentFigmaNode?.name}, depth:{nodeRecursionDepth}, " +
+                $"includedPageObject:{includedPageObject}, withinComponentDefinition:{withinComponentDefinition}, isInnerInstance:{isInnerInstance}"
+            );
+
             // Create a gameObject for this figma node and parent to parent transform
             var nodeGameObject = new GameObject(figmaNode.name, typeof(RectTransform));
             nodeGameObject.transform.SetParent(parentTransform, false);
@@ -209,8 +216,9 @@ namespace UnityFigmaBridge.Editor.Nodes
                 PrototypeFlowManager.ApplyPrototypeFunctionalityToNode(figmaNode, nodeGameObject, figmaImportProcessData);
 
                 // If this is a component, we want to generate a prefab, to be used to link to instances later
-                if (figmaNode.type == NodeType.COMPONENT)
-                    ComponentManager.GenerateComponentAssetFromNode(figmaNode, parentFigmaNode, nodeGameObject, figmaImportProcessData);
+                //if (figmaNode.type == NodeType.COMPONENT)
+                  
+                ComponentManager.GenerateComponentAssetFromNode(figmaNode, parentFigmaNode, nodeGameObject, figmaImportProcessData);
                 
                 return nodeGameObject;
             }
@@ -275,6 +283,7 @@ namespace UnityFigmaBridge.Editor.Nodes
                     break;
                 // For the originally defined components, save as a prefab to be used for later instantiation
                 case NodeType.COMPONENT:
+                case NodeType.COMPONENT_SET:
                     ComponentManager.GenerateComponentAssetFromNode(figmaNode, parentFigmaNode, nodeGameObject, figmaImportProcessData);
                     break;
                 case NodeType.SECTION:

--- a/UnityFigmaBridge/Editor/Nodes/FigmaAssetGenerator.cs
+++ b/UnityFigmaBridge/Editor/Nodes/FigmaAssetGenerator.cs
@@ -136,14 +136,14 @@ namespace UnityFigmaBridge.Editor.Nodes
                 $"includedPageObject:{includedPageObject}, withinComponentDefinition:{withinComponentDefinition}, isInnerInstance:{isInnerInstance}"
             );
 
-            // Create a gameObject for this figma node and parent to parent transform
+            // このFigmaノード用のGameObjectを作成し、親Transformの子にする
             var nodeGameObject = new GameObject(figmaNode.name, typeof(RectTransform));
             nodeGameObject.transform.SetParent(parentTransform, false);
             var nodeRectTransform = nodeGameObject.transform as RectTransform;
             
-            // In some cases we want nodes to be substituted a server-rendered bitmap. Check to see if this is needed
+            // 場合によってはサーバー描画済みビットマップに置き換える必要があるため、その対象かどうか確認する
             var matchingServerRenderEntry = figmaImportProcessData.ServerRenderNodes.FirstOrDefault((testNode) => testNode.SourceNode.id == figmaNode.id);
-            // Apply transform. For server render entries, use absolute bounding box
+            // Transformを適用する。サーバーレンダー対象の場合は absolute bounding box を使う
             if (matchingServerRenderEntry != null)
             {
                 NodeTransformManager.ApplyAbsoluteBoundsFigmaTransform(nodeRectTransform, figmaNode, parentFigmaNode,nodeRecursionDepth >0);
@@ -158,16 +158,16 @@ namespace UnityFigmaBridge.Editor.Nodes
             var figmaNodeObject = nodeGameObject.AddComponent<FigmaNodeObject>();
             figmaNodeObject.Initialise(figmaNode.id, figmaNode.name);
 
-            // If this is a Figma mask object we'll add a mask component (but dont render) 
+            // このノードがFigmaのマスクオブジェクトであれば、Maskコンポーネントを追加する（描画はしない）
             if (figmaNode.isMask)
             {
                 var mask=nodeGameObject.AddComponent<Mask>();
                 mask.showMaskGraphic = false;
             }
             
-            // For component instances, we want to check if there is an existing definition
-            // If so, we wont create the full node, but mark it with a "component node marker" component
-            // At a later stage, we'll replace with an instantiated prefab and apply properties
+            // コンポーネントインスタンスの場合、既存定義があるかを確認する
+            // 存在する場合はフルノードを生成せず、「component node marker」コンポーネントを付けておく
+            // 後段でPrefabをInstantiateし、プロパティを適用して置き換える
             // インスタンスの場合
             if (figmaNode.type == NodeType.INSTANCE)
             {
@@ -192,7 +192,7 @@ namespace UnityFigmaBridge.Editor.Nodes
                 if (figmaImportProcessData.NodeLookupDictionary.TryGetValue(figmaNode.componentId, out var componentNode))
                 {
                     // コンポーネント用のマーカーをつける
-                    // Attach a placeholder transform and component which will get replaced on second pass
+                    // プレースホルダーTransformとコンポーネントを付与し、2回目の処理で置き換える
                     nodeGameObject.AddComponent<FigmaComponentNodeMarker>().Initialise(figmaNode.id, parentFigmaNode.id, figmaNode.componentId);
                     if (componentNode.Is9Slice())
                     {
@@ -202,89 +202,96 @@ namespace UnityFigmaBridge.Editor.Nodes
                 }
                 
                 Debug.Log($"<color=yellow>コンポーネントが存在しなかった\nid:{figmaNode.componentId}, name:{figmaNode.name}</color>");
-                // Otherwise we assume we are missing the definition, so just create as normal
+                // それ以外の場合は定義が見つからないとみなし、通常ノードとして生成する
             }
 
             if (figmaNode.type == NodeType.COMPONENT) withinComponentDefinition = true;
             
             if (matchingServerRenderEntry!=null)
             {
-                // Attach a simple image node (no need for custom renderer)
+                // 単純な画像ノードを付与する（カスタムレンダラーは不要）
                 nodeGameObject.AddComponent<Image>().sprite = AssetDatabase.LoadAssetAtPath<Sprite>(FigmaPaths.GetPathForServerRenderedImage(figmaNode.id,figmaImportProcessData.ServerRenderNodes));
                 
-                // This could be a button, so check for prototype functionality
+                // ボタンの可能性があるため、プロトタイプ機能を確認して適用する
                 PrototypeFlowManager.ApplyPrototypeFunctionalityToNode(figmaNode, nodeGameObject, figmaImportProcessData);
 
-                // If this is a component, we want to generate a prefab, to be used to link to instances later
-                //if (figmaNode.type == NodeType.COMPONENT)
-                  
-                ComponentManager.GenerateComponentAssetFromNode(figmaNode, parentFigmaNode, nodeGameObject, figmaImportProcessData);
+                // If this node is visible, mark the game object is inactive
+                if (!figmaNode.visible) nodeGameObject.SetActive(false);
+
+                if (ShouldTryMergeExistingPrefab(figmaNode))
+                {
+                    ComponentManager.TryMergeWithExistingPrefab(figmaNode, nodeGameObject);
+                }
+
+                if (ShouldGenerateComponentAsset(figmaNode, parentFigmaNode, figmaImportProcessData))
+                {
+                    Debug.Log($"[ComponentPrefab] Generate/Merge target: {figmaNode.name} type={figmaNode.type} id={figmaNode.id}");
+                    ComponentManager.GenerateComponentAssetFromNode(figmaNode, parentFigmaNode, nodeGameObject, figmaImportProcessData);
+                }
                 
                 return nodeGameObject;
             }
             
-            // Create any required unity components for this figmaNode. We separate out application of properties to a separate method
+            // このfigmaNodeに必要なUnityコンポーネントを生成する
+            // プロパティ適用は別メソッドに分ける
             FigmaNodeManager.CreateUnityComponentsForNode(nodeGameObject, figmaNode,figmaImportProcessData);
             
-            // Apply properties for this figmaNode
+            // このfigmaNodeのプロパティを適用する
             FigmaNodeManager.ApplyUnityComponentPropertiesForNode(nodeGameObject,figmaNode,figmaImportProcessData);
             
-            // Apply effects for this figmaNode (if there is an effects node. Some dont have this (eg SECTION)
+            // このfigmaNodeにエフェクトがある場合は適用する（SECTIONなど一部はeffectsを持たない）
             if (figmaNode.effects!=null) EffectManager.ApplyAllFigmaEffectsToUnityNode(nodeGameObject,figmaNode,figmaImportProcessData);
             
-            // Apply layout properties to this node as required (eg vertical layout groups etc). This also implements scrolling
+            // 必要に応じてレイアウトプロパティを適用する（VerticalLayoutGroup など）。スクロール実装もここで行う
             FigmaLayoutManager.ApplyLayoutPropertiesForNode(nodeGameObject,figmaNode,figmaImportProcessData,out var scrollContentGameObject);
             
-            // Build children for this node, if they exist
-			// 9Sliceオブジェクトの子要素の場合生成しない
+            // 子ノードが存在する場合は生成する
+            // 9Sliceオブジェクトの子要素は生成しない
             if (figmaNode.children != null && 
                 !figmaNode.customCondition.Is9Slice())
             {
-                // We'll track any active masking when building child nodes, as masked nodes need to be parented
+                // 子ノード生成中に有効なマスクを追跡する。マスク���象ノードはその配下に親子付けする必要がある
                 Mask activeMaskObject=null;
                 foreach (var childNode in figmaNode.children)
                 {
                     var childGameObject = BuildFigmaNode(childNode, nodeRectTransform, figmaNode,
                         nodeRecursionDepth + 1, figmaImportProcessData,includedPageObject, withinComponentDefinition, isInnerInstance);
                     if (childGameObject == null) continue;
-                    // Check if this object has a mask component. If so, set as the active mask component
+                    // このオブジェクトがMaskコンポーネントを持っていれば、現在のアクティブマスクとして保持する
                     var childGameObjectMask = childGameObject.GetComponent<Mask>();
                     if (childGameObjectMask != null) activeMaskObject = childGameObjectMask;
                     else
                     {
-                        // If there is a current mask object Parent this object to the current mask object and keep current transition
+                        // 現在マスクオブジェクトがある場合は、その子に付け替える（現在のTransformは維持）
                         if (activeMaskObject != null) childGameObject.transform.SetParent(activeMaskObject.transform, true);
-                        // If there is an active scroll content object (generated by layout properties), parent to that object instead
+                        // レイアウトによってScrollContentが生成されている場合は、そちらを親にする
                         if (scrollContentGameObject!=null) childGameObject.transform.SetParent(scrollContentGameObject.transform, true);
                     }
                 }
             }
             
-            // For a final step on creation of scroll content. If the node doesnt use layout, we need to resize to fit all the generated children
+            // スクロールコンテンツ生成の最終処理
+            // レイアウト未使用の場合は、生成された子全体が収まるようにサイズを再計算する
             if (scrollContentGameObject != null && figmaNode.layoutMode == Node.LayoutMode.NONE)
             {
-                // We do this by calculating the merged bounds of all child nodes
+                // すべての子ノードの結合Boundsを計算する
                 var boundsRect = NodeTransformManager.GetRelativeBoundsForAllChildNodes(figmaNode);
                 ((RectTransform)scrollContentGameObject.transform).sizeDelta = new Vector2(boundsRect.xMax, boundsRect.yMax);
             }
             
-            // Apply prototype elements for this figmaNode
-            // This needs to be done AFTER children as some children will be needed for some button variations
+            // このfigmaNodeのプロトタイプ要素を適用する
+            // 一部のボタンバリエーションでは子が必要になるため、子生成後に行う必要がある
             PrototypeFlowManager.ApplyPrototypeFunctionalityToNode(figmaNode ,nodeGameObject, figmaImportProcessData);
 
             switch (figmaNode.type)
             {
-                // If the parent is either a canvas or section, treat as a flowScreen and create a prefab. Only do this if it's on a generated page
+                // 親が canvas または section の場合は flowScreen として扱い、Prefabを作成する
+                // ただし生成対象ページ上にある場合に限る
                 case NodeType.FRAME:
                     if (includedPageObject && FigmaDataUtils.IsScreenNode(figmaNode,parentFigmaNode))
                     {
                         SaveFigmaScreenAsPrefab(figmaNode, parentFigmaNode, nodeRectTransform, figmaImportProcessData);
                     }
-                    break;
-                // For the originally defined components, save as a prefab to be used for later instantiation
-                case NodeType.COMPONENT:
-                case NodeType.COMPONENT_SET:
-                    ComponentManager.GenerateComponentAssetFromNode(figmaNode, parentFigmaNode, nodeGameObject, figmaImportProcessData);
                     break;
                 case NodeType.SECTION:
                     RegisterFigmaSection(figmaNode, figmaImportProcessData);
@@ -294,9 +301,41 @@ namespace UnityFigmaBridge.Editor.Nodes
             // If this node is visible, mark the game object is inactive
             if (!figmaNode.visible) nodeGameObject.SetActive(false);
             
+            if (ShouldTryMergeExistingPrefab(figmaNode))
+            {
+                ComponentManager.TryMergeWithExistingPrefab(figmaNode, nodeGameObject);
+            }
+
+            if (ShouldGenerateComponentAsset(figmaNode, parentFigmaNode, figmaImportProcessData))
+            {
+                Debug.Log($"[ComponentPrefab] Generate/Merge target: {figmaNode.name} type={figmaNode.type} id={figmaNode.id}");
+                ComponentManager.GenerateComponentAssetFromNode(figmaNode, parentFigmaNode, nodeGameObject, figmaImportProcessData);
+            }
+
             return nodeGameObject;
         }
 
+        /// <summary>
+        /// 既存Prefabとのマージを試みるべきノードかどうかを判定する。
+        /// ここではノード種別では絞り込まず、既存アセットが存在する可能性があるノードを広く対象にする。
+        /// 実際にマージされるかどうかは TryMergeWithExistingPrefab 内で
+        /// GUIDマップとPrefabパスが見つかるかどうかで最終判定する。
+        /// </summary>
+        /// <param name="node">判定対象のFigmaノード</param>
+        /// <returns>
+        /// 既存Prefabとのマージを試行してよい場合は true。
+        /// 外部コンポーネントなど、ローカルPrefabを扱わないノードは false。
+        /// </returns>
+        private static bool ShouldTryMergeExistingPrefab(Node node)
+        {
+            if (node == null) return false;
+
+            // 外部コンポーネントはローカルPrefabとマージしない
+            if (ImportSessionCache.remoteComponentFlagMap.Contains(node.id))
+                return false;
+
+            return true;
+        }
 
         /// <summary>
         /// Create a flowScreen prefab from a generated figma asset

--- a/UnityFigmaBridge/Editor/Nodes/FigmaAssetGenerator.cs
+++ b/UnityFigmaBridge/Editor/Nodes/FigmaAssetGenerator.cs
@@ -218,11 +218,6 @@ namespace UnityFigmaBridge.Editor.Nodes
                 // If this node is visible, mark the game object is inactive
                 if (!figmaNode.visible) nodeGameObject.SetActive(false);
 
-               // if (ShouldTryMergeExistingPrefab(figmaNode))
-               // {
-                   // ComponentManager.TryMergeWithExistingPrefab(figmaNode, nodeGameObject);
-               // }
-
                 if (ShouldGenerateComponentAsset(figmaNode, parentFigmaNode, figmaImportProcessData))
                 {
                     Debug.Log($"[ComponentPrefab] Generate/Merge target: {figmaNode.name} type={figmaNode.type} id={figmaNode.id}");
@@ -307,11 +302,6 @@ namespace UnityFigmaBridge.Editor.Nodes
 
             // If this node is visible, mark the game object is inactive
             if (!figmaNode.visible) nodeGameObject.SetActive(false);
-            
-            // if (ShouldTryMergeExistingPrefab(figmaNode))
-            // {
-            //     ComponentManager.TryMergeWithExistingPrefab(figmaNode, nodeGameObject);
-            // }
 
             if (ShouldGenerateComponentAsset(figmaNode, parentFigmaNode, figmaImportProcessData))
             {

--- a/UnityFigmaBridge/Editor/PrototypeFlow/BehaviourBindingManager.cs
+++ b/UnityFigmaBridge/Editor/PrototypeFlow/BehaviourBindingManager.cs
@@ -246,16 +246,24 @@ namespace UnityFigmaBridge.Editor.PrototypeFlow
         /// <param name="figmaImportProcessData"></param>
         private static void BindBehaviourToNodeAndChildren(GameObject targetGameObject,FigmaImportProcessData figmaImportProcessData)
         {
-           // Apply depth-first application of node behaviours (as assumes parent nodes will want ref to children rather than vice versa)
-           var numChildren = targetGameObject.transform.childCount;
-           for (var i = 0; i < numChildren; i++)
-           {
-               // Apply to child nodes first
-               var childTransform = targetGameObject.transform.GetChild(i);
-               BindBehaviourToNodeAndChildren(childTransform.gameObject, figmaImportProcessData);
-           }
-           // Finally apply to this node
-           BindBehaviourToNode(targetGameObject, figmaImportProcessData);
+            var transform = targetGameObject.transform;
+
+            var children = new List<Transform>(transform.childCount);
+            for (int i = 0; i < transform.childCount; i++)
+            {
+                children.Add(transform.GetChild(i));
+            }
+
+            //項目が増減してエラーになることがあったため配列を保持してから回す
+            foreach (var childTransform in children)
+            {
+                if (childTransform == null) continue;
+
+                BindBehaviourToNodeAndChildren(childTransform.gameObject, figmaImportProcessData);
+            }
+
+            // 自分自身への処理
+            BindBehaviourToNode(targetGameObject, figmaImportProcessData);
         }
 
         private static void ApplyInsatanceSwap(GameObject gameObject)

--- a/UnityFigmaBridge/Editor/UnityFigmaBridgeImporter.cs
+++ b/UnityFigmaBridge/Editor/UnityFigmaBridgeImporter.cs
@@ -19,8 +19,6 @@ using UnityFigmaBridge.Editor.Settings;
 using UnityFigmaBridge.Editor.Utils;
 using UnityFigmaBridge.Runtime.UI;
 using Object = UnityEngine.Object;
-using Newtonsoft.Json;
-using System.IO;
 
 namespace UnityFigmaBridge.Editor
 {

--- a/UnityFigmaBridge/Editor/UnityFigmaBridgeImporter.cs
+++ b/UnityFigmaBridge/Editor/UnityFigmaBridgeImporter.cs
@@ -19,6 +19,8 @@ using UnityFigmaBridge.Editor.Settings;
 using UnityFigmaBridge.Editor.Utils;
 using UnityFigmaBridge.Runtime.UI;
 using Object = UnityEngine.Object;
+using Newtonsoft.Json;
+using System.IO;
 
 namespace UnityFigmaBridge.Editor
 {
@@ -732,6 +734,57 @@ namespace UnityFigmaBridge.Editor
                 // Destroy temporary canvas
                 Object.DestroyImmediate(s_SceneCanvas.gameObject);
             }
+        }
+
+        
+[MenuItem("Figma Bridge/Sync Test")]
+        public static void SyncTest()
+        {
+            
+            string path = Path.Combine(Application.dataPath, "FigmaOutput.json");
+            string json = File.ReadAllText(path);
+            SyncAsync(json);
+        }
+        public static async void SyncAsync(string json)
+        {
+            ImportSessionCache.CacheClear();//キャッシュの削除
+            
+            var requirementsMet = CheckRequirements();
+            if (!requirementsMet) return;
+            
+            FigmaFile figmaFile;
+            List<Node> pageNodeList;
+            try
+            {
+                // Create a settings object to ignore missing members and null fields that sometimes come from Figma
+                JsonSerializerSettings settings = new JsonSerializerSettings()
+                {
+                    DefaultValueHandling = DefaultValueHandling.Include,
+                    MissingMemberHandling = MissingMemberHandling.Ignore,
+                    NullValueHandling = NullValueHandling.Ignore,
+                };
+                
+                // Deserialize the document
+                figmaFile = JsonConvert.DeserializeObject<FigmaFile>(json, settings);
+                Debug.Log($"Figma file downloaded, name {figmaFile.name}");
+            }
+            catch (Exception e)
+            {
+                throw new Exception($"Problem decoding Figma document JSON {e.ToString()}");
+            }
+            
+            if (figmaFile == null) return;
+            pageNodeList = FigmaDataUtils.GetPageNodes(figmaFile);
+            
+            //ファイル名の設定
+            FigmaPaths.SetCurrentFigmaFileName(figmaFile.name);
+            // 画像キャッシュここで構築しておく
+            FigmaAssetGuidMapManager.CreateMap(FigmaAssetGuidMapManager.AssetType.ImageFill);
+            
+            await ImportDocument(s_UnityFigmaBridgeSettings.FileId, figmaFile, pageNodeList);
+            
+            FigmaAssetGuidMapManager.SaveAllMap();
+            ImportSessionCache.CacheClear();
         }
         
     }

--- a/UnityFigmaBridge/Editor/UnityFigmaBridgeImporter.cs
+++ b/UnityFigmaBridge/Editor/UnityFigmaBridgeImporter.cs
@@ -735,57 +735,6 @@ namespace UnityFigmaBridge.Editor
                 Object.DestroyImmediate(s_SceneCanvas.gameObject);
             }
         }
-
-        
-[MenuItem("Figma Bridge/Sync Test")]
-        public static void SyncTest()
-        {
-            
-            string path = Path.Combine(Application.dataPath, "FigmaOutput.json");
-            string json = File.ReadAllText(path);
-            SyncAsync(json);
-        }
-        public static async void SyncAsync(string json)
-        {
-            ImportSessionCache.CacheClear();//キャッシュの削除
-            
-            var requirementsMet = CheckRequirements();
-            if (!requirementsMet) return;
-            
-            FigmaFile figmaFile;
-            List<Node> pageNodeList;
-            try
-            {
-                // Create a settings object to ignore missing members and null fields that sometimes come from Figma
-                JsonSerializerSettings settings = new JsonSerializerSettings()
-                {
-                    DefaultValueHandling = DefaultValueHandling.Include,
-                    MissingMemberHandling = MissingMemberHandling.Ignore,
-                    NullValueHandling = NullValueHandling.Ignore,
-                };
-                
-                // Deserialize the document
-                figmaFile = JsonConvert.DeserializeObject<FigmaFile>(json, settings);
-                Debug.Log($"Figma file downloaded, name {figmaFile.name}");
-            }
-            catch (Exception e)
-            {
-                throw new Exception($"Problem decoding Figma document JSON {e.ToString()}");
-            }
-            
-            if (figmaFile == null) return;
-            pageNodeList = FigmaDataUtils.GetPageNodes(figmaFile);
-            
-            //ファイル名の設定
-            FigmaPaths.SetCurrentFigmaFileName(figmaFile.name);
-            // 画像キャッシュここで構築しておく
-            FigmaAssetGuidMapManager.CreateMap(FigmaAssetGuidMapManager.AssetType.ImageFill);
-            
-            await ImportDocument(s_UnityFigmaBridgeSettings.FileId, figmaFile, pageNodeList);
-            
-            FigmaAssetGuidMapManager.SaveAllMap();
-            ImportSessionCache.CacheClear();
-        }
         
     }
 }

--- a/UnityFigmaBridge/Editor/Utils/FigmaPaths.cs
+++ b/UnityFigmaBridge/Editor/Utils/FigmaPaths.cs
@@ -210,7 +210,7 @@ namespace UnityFigmaBridge.Editor.Utils
             }
             foreach (var file in new DirectoryInfo(FigmaPagePrefabFolder).GetFiles())
             {
-                file.Delete();
+               // file.Delete();
             }
 
             // Screens
@@ -220,7 +220,7 @@ namespace UnityFigmaBridge.Editor.Utils
             }
             foreach (var file in new DirectoryInfo(FigmaScreenPrefabFolder).GetFiles())
             {
-                file.Delete();
+               // file.Delete();
             }
 
             // Components

--- a/UnityFigmaBridge/Editor/Utils/FigmaPaths.cs
+++ b/UnityFigmaBridge/Editor/Utils/FigmaPaths.cs
@@ -208,20 +208,16 @@ namespace UnityFigmaBridge.Editor.Utils
             {
                 Directory.CreateDirectory(FigmaPagePrefabFolder);
             }
-            foreach (var file in new DirectoryInfo(FigmaPagePrefabFolder).GetFiles())
-            {
-               // file.Delete();
-            }
+            // コンポーネント参照で使うのでここでは消さない
+            // ComponentManager.RemoveUnusedTargetsで消える想定
 
             // Screens
             if (!Directory.Exists(FigmaScreenPrefabFolder))
             {
                 Directory.CreateDirectory(FigmaScreenPrefabFolder);
             }
-            foreach (var file in new DirectoryInfo(FigmaScreenPrefabFolder).GetFiles())
-            {
-               // file.Delete();
-            }
+            // コンポーネント参照で使うのでここでは消さない
+            // ComponentManager.RemoveUnusedTargetsで消える想定
 
             // Components
             if (!Directory.Exists(FigmaComponentPrefabFolder))

--- a/UnityFigmaBridge/Runtime/UI/FigmaNodeObject.cs
+++ b/UnityFigmaBridge/Runtime/UI/FigmaNodeObject.cs
@@ -1,5 +1,4 @@
-﻿#if UNITY_EDITOR
-
+﻿
 using UnityEngine;
 
 namespace UnityFigmaBridge.Runtime.UI
@@ -11,6 +10,7 @@ namespace UnityFigmaBridge.Runtime.UI
     public class FigmaNodeObject : MonoBehaviour
     {
         // Reference to the full FIGMA node id
+        #if UNITY_EDITOR
         public string NodeId;
 
         public string NodeName;
@@ -25,6 +25,6 @@ namespace UnityFigmaBridge.Runtime.UI
             NodeName = nodeName;
             Debug.Log($"==== Initialised明示的に初期化するための関数 {NodeId} and NodeName {NodeName}");
         }
+        #endif
     }
 }
-#endif

--- a/UnityFigmaBridge/Runtime/UI/FigmaNodeObject.cs
+++ b/UnityFigmaBridge/Runtime/UI/FigmaNodeObject.cs
@@ -1,4 +1,4 @@
-﻿＃if UNITY_EDITOR
+﻿#if UNITY_EDITOR
 
 using UnityEngine;
 

--- a/UnityFigmaBridge/Runtime/UI/FigmaNodeObject.cs
+++ b/UnityFigmaBridge/Runtime/UI/FigmaNodeObject.cs
@@ -1,4 +1,6 @@
-﻿using UnityEngine;
+﻿＃if UNITY_EDITOR
+
+using UnityEngine;
 
 namespace UnityFigmaBridge.Runtime.UI
 {
@@ -25,3 +27,4 @@ namespace UnityFigmaBridge.Runtime.UI
         }
     }
 }
+#endif

--- a/UnityFigmaBridge/Runtime/UI/FigmaNodeObject.cs
+++ b/UnityFigmaBridge/Runtime/UI/FigmaNodeObject.cs
@@ -10,5 +10,17 @@ namespace UnityFigmaBridge.Runtime.UI
     {
         // Reference to the full FIGMA node id
         public string NodeId;
+
+        public string NodeName;
+
+        /// <summary>
+        /// 明示的に初期化するための関数。
+        /// Sync 時の差分マッチングで利用する値をここで設定する。
+        /// </summary>
+        public void Initialise(string nodeId, string nodeName)
+        {
+            NodeId = nodeId;
+            NodeName = nodeName;
+        }
     }
 }

--- a/UnityFigmaBridge/Runtime/UI/FigmaNodeObject.cs
+++ b/UnityFigmaBridge/Runtime/UI/FigmaNodeObject.cs
@@ -9,8 +9,8 @@ namespace UnityFigmaBridge.Runtime.UI
     /// </summary>
     public class FigmaNodeObject : MonoBehaviour
     {
-        // Reference to the full FIGMA node id
         #if UNITY_EDITOR
+        // Reference to the full FIGMA node id
         public string NodeId;
 
         public string NodeName;

--- a/UnityFigmaBridge/Runtime/UI/FigmaNodeObject.cs
+++ b/UnityFigmaBridge/Runtime/UI/FigmaNodeObject.cs
@@ -21,6 +21,7 @@ namespace UnityFigmaBridge.Runtime.UI
         {
             NodeId = nodeId;
             NodeName = nodeName;
+            Debug.Log($"==== Initialised明示的に初期化するための関数 {NodeId} and NodeName {NodeName}");
         }
     }
 }


### PR DESCRIPTION
コメントは次チケットでもそのまま参照したいので残しています。

-バックアップを残さないで既存オブジェクトと比べてコンポーネントを設定するように設定。
-NodeType.FRAMEの場合既存コンポーネント引継ぎができてないのを修正
-AttachComponentで不具合が起きてたのを修正


